### PR TITLE
Add additional actions on sync error

### DIFF
--- a/sdk/src/MSError.h
+++ b/sdk/src/MSError.h
@@ -94,6 +94,9 @@ extern NSString *const MSErrorPushResultKey;
 /// Indicates a sync table operation could not be canceled
 #define MSSyncTableCancelError                  -1156
 
+/// Indicates a sync table operation could not be updated/removed as it no longer exists
+#define MSSyncTableOperationNotFound            -1157
+
 /// Indicates a mobile service sync operation (such as a syncTable insert) failed
 /// because the sync context object was not properly initialized
 #define MSSyncContextInvalid                    -1160

--- a/sdk/src/MSOperationQueue.h
+++ b/sdk/src/MSOperationQueue.h
@@ -21,6 +21,9 @@
 /// Removes a given operation from the queue
 -(void) removeOperation:(MSTableOperation *)operation orError:(NSError **)error;
 
+/// Checks that an operation is present, and if so, updates it in place
+-(void) updateOperation:(MSTableOperation *)operation orError:(NSError **)error;
+
 /// Analyzes the given operation and condenses it with any already in the queue
 /// Letting the last table-item operation win in the queue
 -(BOOL) condenseOperation:(MSTableOperation *)operation orError:(NSError **)error;

--- a/sdk/src/MSSyncContext.m
+++ b/sdk/src/MSSyncContext.m
@@ -352,6 +352,34 @@ static NSOperationQueue *pushQueue_;
     });
 }
 
+-(void) updateOperation:(MSTableOperation *)operation updateItem:(NSDictionary *)item completion:(MSSyncBlock)completion
+{
+    // updating an operation requires write access to the queue
+    dispatch_async(writeOperationQueue, ^{
+        NSError *error;
+        
+        if (operation.type == MSTableOperationDelete) {
+            [self.dataSource deleteItemsWithIds:@[operation.itemId]
+                                          table:operation.tableName
+                                        orError:&error];
+            operation.item = item;
+        } else {
+            [self.dataSource upsertItems:@[item] table:operation.tableName orError:&error];
+            operation.item = nil;
+        }
+        
+        if (!error) {
+            [self.operationQueue updateOperation:operation orError:&error];
+        }
+        
+        if (completion) {
+            [self.callbackQueue addOperationWithBlock:^{
+                completion(error);
+            }];
+        }
+    });
+}
+
 /// Verify our input is valid and try to pull our data down from the server
 - (NSOperation *) pullWithQuery:(MSQuery *)query queryId:(NSString *)queryId settings:(MSPullSettings *)pullSettings completion:(MSSyncBlock)completion;
 {

--- a/sdk/src/MSSyncContextInternal.h
+++ b/sdk/src/MSSyncContextInternal.h
@@ -46,4 +46,6 @@
 
 -(void) cancelOperation:(MSTableOperation *)operation discardItemWithCompletion:(MSSyncBlock)completion;
 
+-(void) updateOperation:(MSTableOperation *)operation updateItem:(NSDictionary *)item completion:(MSSyncBlock)completion;
+
 @end

--- a/sdk/src/MSTableOperationError.h
+++ b/sdk/src/MSTableOperationError.h
@@ -69,6 +69,14 @@
 /// removes the item associated with the operation from the local store
 - (void) cancelOperationAndDiscardItemWithCompletion:(nullable MSSyncBlock)completion;
 
+/// Adjusts the specified operation and saves the given item back into the store depending on the state of the
+/// new operation
+- (void) keepOperationAndUpdateItem:(nonnull NSDictionary *)item completion:(nullable MSSyncBlock)completion;
+
+- (void) modifyOperationType:(MSTableOperationTypes)type completion:(nullable MSSyncBlock)completion;
+
+- (void) modifyOperationType:(MSTableOperationTypes)type AndUpdateItem:(nonnull NSDictionary *)item completion:(nullable MSSyncBlock)completion;
+
 
 /// @name Initializing the MSTableOperationError Object
 /// @{

--- a/sdk/test/MSTableOperationErrorTests.m
+++ b/sdk/test/MSTableOperationErrorTests.m
@@ -59,7 +59,7 @@
     XCTAssertEqualObjects(opError.table, @"TodoItem");
     XCTAssertEqual(opError.code, MSErrorPreconditionFailed);
     XCTAssertEqualObjects(opError.domain, MSErrorDomain);
-    XCTAssertEqualObjects(opError.description, @"Insert error...");
+    XCTAssertEqualObjects(opError.description, @"Fake error...");
 }
 
 -(void) testSerializedInit {
@@ -153,7 +153,6 @@
 -(void) testCancelAndUpdate_NoItem {
     MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItem];
     
-    
     // Cancel our pending operation and update the stored value
     XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAndUpdateOperation"];
     [opError cancelOperationAndUpdateItem:nil completion:^(NSError *error) {
@@ -163,23 +162,218 @@
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
     
     // Verify operation is still in the local store layer
-    NSError *error = nil;
-    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
-    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
-    XCTAssertNil(error);
-    XCTAssertEqual(allOps.count, 1);
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+}
+
+-(void) testKeepOperationAndUpdateItem_Update {
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationUpdate];
+
+    // keep our pending operation and update the stored value
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
     
+    XCTestExpectation *expectation = [self expectationWithDescription:@"KeepOperationAndUpdate"];
+    [opError keepOperationAndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+
+    // Check that the item is updated
+    // Check that the item is updated
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNotNil(item);
+    XCTAssertEqualObjects(@"value two", item[@"text"]);
+
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+}
+
+-(void) testKeepOperationAndUpdateItem_Delete {
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationDelete];
+    
+    // keep our pending operation and update the stored value
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"KeepOperationAndUpdate"];
+    [opError keepOperationAndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the item is not present
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNil(item);
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertNotNil(op.item);
+    XCTAssertEqualObjects(@"value two", op.item[@"text"]);
+}
+
+-(void) testModifyOperationType_InsertToUpdate
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationInsert];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    
+    [opError modifyOperationType:MSTableOperationUpdate completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(MSTableOperationUpdate, op.type);
+    
+    // Check that the item is still there
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNotNil(item);
+    XCTAssertEqualObjects(@"initial value", item[@"text"]);
+}
+
+-(void) testModifyOperationType_UpdateToDelete
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationUpdate];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    
+    [opError modifyOperationType:MSTableOperationDelete completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(MSTableOperationDelete, op.type);
+    XCTAssertNotNil(op.item);
+
+    // Check that the item is gone
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNil(item);
+}
+
+-(void) testModifyOperationType_DeleteToUpdate
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationDelete];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    
+    [opError modifyOperationType:MSTableOperationUpdate completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check the item was put back
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNotNil(item);
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(MSTableOperationUpdate, op.type);
+}
+
+-(void) testModifyOperationAndItem_InsertToUpdate
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationInsert];
+    
+    // keep our pending operation and update the stored value
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    [opError modifyOperationType:MSTableOperationUpdate AndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the item is updated
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNotNil(item);
+    XCTAssertEqualObjects(@"value two", item[@"text"]);
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(op.type, MSTableOperationUpdate);
+}
+
+-(void) testModifyOperationAndItem_UpdateToDelete
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationUpdate];
+    
+    // keep our pending operation and update the stored value
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    [opError modifyOperationType:MSTableOperationDelete AndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the item is present
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNil(item);
+
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(op.type, MSTableOperationDelete);
+    XCTAssertNotNil(op.item);
+    XCTAssertEqualObjects(@"value two", op.item[@"text"]);
+}
+
+-(void) testModifyOperationAndItem_DeleteToInsert
+{
+    MSTableOperationError *opError = [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationDelete];
+    
+    // keep our pending operation and update the stored value
+    NSDictionary *newItem = @{ @"id": @"ABC", @"text": @"value two" };
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"ModifyOperation"];
+    [opError modifyOperationType:MSTableOperationInsert AndUpdateItem:newItem completion:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1000 handler:nil];
+    
+    // Check that the item is present
+    NSDictionary *item = [self defaultItemFromStore];
+    XCTAssertNotNil(item);
+    
+    // Check that the operation is still in the queue
+    MSTableOperation *op = [self getOperationFromStore];
+    XCTAssertNotNil(op);
+    XCTAssertEqual(op.type, MSTableOperationInsert);
 }
 
 - (MSTableOperationError *) createErrorAndPendingOpForDefaultItem
 {
+    return [self createErrorAndPendingOpForDefaultItemOfType:MSTableOperationUpdate];
+}
+
+- (MSTableOperationError *) createErrorAndPendingOpForDefaultItemOfType:(MSTableOperationTypes)type
+{
     NSDictionary *item = @{ @"id": @"ABC", @"text": @"initial value" };
     
-    MSTableOperation *tableOp = [self createPendingOperationForItem:item];
+    MSTableOperation *tableOp = [self createPendingOperationForItem:item ofType:type];
     
     NSError *error = [NSError errorWithDomain:MSErrorDomain
-                                        code:MSErrorPreconditionFailed
-                                    userInfo:@{NSLocalizedDescriptionKey: @"Insert error..."}];
+                                         code:MSErrorPreconditionFailed
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Fake error..."}];
     
     return [[MSTableOperationError alloc] initWithOperation:tableOp
                                                        item:item
@@ -187,15 +381,29 @@
                                                       error:error];
 }
 
-- (MSTableOperation *) createPendingOperationForItem:(NSDictionary *)item
+- (MSTableOperation *) createPendingOperationForItem:(NSDictionary *)item ofType:(MSTableOperationTypes)type
 {
     MSSyncTable *table = [client syncTableWithName:@"TodoItem"];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"UpsertRecord"];
-    [table update:item completion:^(NSError *error) {
-        XCTAssertNil(error);
-        [expectation fulfill];
-    }];
+    
+    if (type == MSTableOperationInsert) {
+        [table insert:item completion:^(NSDictionary *insertedItem, NSError *error) {
+            XCTAssertNil(error);
+            [expectation fulfill];
+        }];
+    } else if (type == MSTableOperationUpdate) {
+        [table update:item completion:^(NSError *error) {
+            XCTAssertNil(error);
+            [expectation fulfill];
+        }];
+    } else {
+        [table delete:item completion:^(NSError *error) {
+            XCTAssertNil(error);
+            [expectation fulfill];
+        }];
+    }
+    
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
 
     // To be safe, verify operation is in the local store layer
@@ -206,10 +414,42 @@
     XCTAssertEqual(allOps.count, 1);
     
     // Create a op that matches what we just did & fake an error
-    MSTableOperation *tableOp = [[MSTableOperation alloc] initWithTable:@"TodoItem" type:MSTableOperationInsert itemId:@"ABC"];
+    MSTableOperation *tableOp = [[MSTableOperation alloc] initWithTable:@"TodoItem" type:type itemId:@"ABC"];
     tableOp.operationId = [[allOps[0] valueForKey:@"id"] integerValue];
 
     return tableOp;
+}
+
+- (MSTableOperation *) getOperationFromStore
+{
+    // Check that the operation is still in the queue
+    NSError *error;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:offline.operationTableName];
+    NSArray *allOps = [context executeFetchRequest:fetchRequest error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertEqual(allOps.count, 1);
+    
+    NSDictionary *operation = [offline tableItemFromManagedObject:allOps[0]];
+    
+    return [[MSTableOperation alloc] initWithItem:operation];
+}
+
+-(NSDictionary *) defaultItemFromStore
+{
+    NSError *error;
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"TodoItem"];
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"(id == 'ABC')"];
+     
+    NSArray *todosWithIdABC = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error);
+    XCTAssertTrue(todosWithIdABC.count < 2);
+    
+    if (todosWithIdABC.count > 0) {
+        return [offline tableItemFromManagedObject:todosWithIdABC[0]];
+    }
+    
+    return nil;
 }
 
 @end


### PR DESCRIPTION
Adds three new methods
- keepOperationAndUpdateItem
- modifyOperationType:
- modifyOperationType:AndUpdateItem:

To help with conflict resolution.