### PR TITLE
Documentation: SyncContext, CoreData Store, Pull Settings

### DIFF
--- a/sdk/src/MSCoreDataStore.h
+++ b/sdk/src/MSCoreDataStore.h
@@ -6,39 +6,53 @@
 #import <CoreData/CoreData.h>
 #import "MSSyncContext.h"
 
-/// The MSCoreDataStore class is for use when using the offline capabilities
-/// of mobile services. This class is a local store which manages records and sync
-/// logic using CoreData.
-/// This class assumes the provided managed object context has the following tables:
-/// MS_TableOperations:      Columns: id (Integer 64), itemId (string), table (string), properties (binary data)
-/// MS_TableOperationErrors: Columns: id (string), properties (binary data)
-/// and all tables contain a ms_version column
+/**
+ The MSCoreDataStore class is for use when using the offline capabilities
+ of mobile services. This class is a local store which manages records and sync
+ logic using CoreData.
+
+ This class assumes the provided managed object context has the following tables:
+ - MS_TableOperations:      Columns: id (Integer 64), itemId (string), table (string), properties (binary data)
+ - MS_TableOperationErrors: Columns: id (string), properties (binary data)
+ - MS_TableConfig:          Columns: id (string), key (string), keyType (integer 64), table (string), value (string)
+ - Your logical tables:     Columns: id (string), any additional columns of your choice
+ */
 @interface MSCoreDataStore : NSObject <MSSyncContextDataSource>
 
 #pragma  mark * Public Static Constructor Methods
 
-/// @name Initializing the MSClient Object
-/// @{
+/** @name Initializing the MSClient object */
 
-/// Creates a CoreDataStore with the given managed object context.
+/** 
+ Creates a CoreDataStore with the given managed object context.
+ 
+ @param context the NSManagedObjectContext to perform all reads/writes to
+ @returns a new MSSyncContext class
+ */
 -(nonnull instancetype) initWithManagedObjectContext:(nonnull NSManagedObjectContext *)context;
 
-/// @}
+/** @name Modifying MSSyncTable behavior */
 
-/// Disables the store from recieving information about the items passed into all sync table
-/// calls (insert, delete, update). If set, the application is responsible for already having
-/// saved the item in the persisten store. This flag is intended to be used when application
-/// code is working directly with NSManagedObjects.
+/**
+ Disables the store from receiving information about the items passed into all sync table
+ calls (insert, delete, update). If set, the application is responsible for already having
+ saved the item in the persisten store. This flag is intended to be used when application
+ code is working directly with NSManagedObjects.
+ */
 @property (nonatomic) BOOL handlesSyncTableOperations;
 
 #pragma mark * Helper functions
 
-/// @{name Working with the table APIs
+/** @name Working with the table APIs */
 
-/// Converts a managed object from the core data layer back into a dictionary with the
-/// properties expected when using a MSTable or MSSyncTable
+/**
+ Converts a managed object from the core data layer back into a dictionary with the
+ properties expected when using a MSTable or MSSyncTable
+ 
+ @param object the NSManagedObject representation of a table's item
+ @returns an NSDictionary representation of the item in the format expected by the server
+ */
 -(nonnull NSDictionary *) tableItemFromManagedObject:(nonnull NSManagedObject *)object;
 
-/// @}
 
 @end

--- a/sdk/src/MSFilter.h
+++ b/sdk/src/MSFilter.h
@@ -6,13 +6,15 @@
 
 #pragma mark * Block Type Definitions
 
+/**
+ Callback that the filter should invoke once an HTTP response (with or without data) or an error
+ has been received by the filter.
+ */
+typedef void (^MSFilterResponseBlock)(NSHTTPURLResponse *__nullable response,
+                                      NSData *__nullable data,
+                                      NSError *__nullable error);
 
-/// Callback that the filter should invoke once an HTTP response (with or
-/// without data) or an error has been received by the filter.
-typedef void (^MSFilterResponseBlock)(NSHTTPURLResponse *__nullable response, NSData *__nullable data, NSError *__nullable error);
-
-/// Callback that the filter should invoke to allow the next filter to handle
-/// the given request.
+/** Callback that the filter should invoke to allow the next filter to handle the given request. */
 typedef void (^MSFilterNextBlock)(NSURLRequest *__nonnull request,
                                   MSFilterResponseBlock __nonnull onResponse);
 
@@ -20,19 +22,26 @@ typedef void (^MSFilterNextBlock)(NSURLRequest *__nonnull request,
 #pragma  mark * MSFilter Public Protocol
 
 
-/// The *MSFilter* protocol allows developers to implement a class that can
-/// inspect and/or replace HTTP request and HTTP response messages being sent
-/// and received by an *MSClient* instance.
+/** 
+ The MSFilter protocol allows developers to implement a class that can inspect and/or replace
+ HTTP request and HTTP response messages being sent and received from an *MSClient* instance.
+ An MSFilter will not be applied to login related actions.
+*/
 @protocol MSFilter <NSObject>
 
-/// @name Modify the request
-/// @{
+/** @name Modify the request */
 
-/// Allows for the inspection and/or modification of the HTTP request and HTTP response messages
-/// being sent and received by an *MSClient* instance.
+/**
+ Allows for the inspection and/or modification of the HTTP request and HTTP response messages
+ being sent and received by an *MSClient* instance.
+
+ @param request the outgoing HTTP request
+ @param next A MSFilterNextBlock to call that allows the next MSFilter to run
+ @param response The MSFilterResponseBlock callback to call once processing is complete,
+                returning control to the previous filter
+ */
 -(void)handleRequest:(nonnull NSURLRequest *)request
                 next:(nonnull MSFilterNextBlock)next
             response:(nonnull MSFilterResponseBlock)response;
 
-///@}
 @end

--- a/sdk/src/MSPullSettings.h
+++ b/sdk/src/MSPullSettings.h
@@ -4,27 +4,28 @@
 
 #import <Foundation/Foundation.h>
 
-/// Settings that control the pull behavior
+/** Settings that control the pull behavior */
+
 @interface MSPullSettings : NSObject
 
 #pragma mark * Initializer method(s)
 
-///@name Initializing the MSPullSettings object
-///@{
+/** @name Initializing the MSPullSettings object */
 
-/// Initializes the MSPullSettings object with the specified page size
+/** 
+ Initializes the MSPullSettings object with the specified page size 
+ 
+ @param pageSize controls how many records are asked for at a time from the server during a pull
+                 operation
+ @returns a new MSPullSettings object
+ */
 - (instancetype)initWithPageSize:(NSInteger)pageSize;
-
-///}
 
 #pragma mark * Properties
 
-///@name Properties that control pull behavior
-///@{
+/** @name Controlling the pull behavior */
 
-/// Size of pages requested from the server while performing a pull
+/** Number of records requested from the server at a time (via $top) */
 @property (nonatomic) NSInteger pageSize;
-
-///@}
 
 @end

--- a/sdk/src/MSSyncContext.h
+++ b/sdk/src/MSSyncContext.h
@@ -10,113 +10,204 @@
 @class MSTableOperation;
 @class MSSyncContextReadResult;
 
-/// The MSSyncContextDelegate allows for customizing the handling of errors, conflicts, and other
-/// conditions that may occur when syncing data between the device and the mobile service.
+/** 
+ The MSSyncContextDelegate allows for customizing the handling of errors, conflicts, and other
+ conditions that may occur when syncing data between the device and the mobile service.
+ */
+
 @protocol MSSyncContextDelegate <NSObject>
 
-/// @name Handling Conflicts and Errors
-/// @{
-
 @optional
-/// Called once for each entry on the queue, allowing for any adjustments to the item before it is sent to the server,
-/// or custom handling of the server's response (such as conflict handling). Errors returned from this function will
-/// be collected and sent as a group to the [syncContext: onPushCompleteWithError: completion:] function.
+
+/** @name Handling Conflicts and Errors */
+
+/**
+ Allows for custom processing to be done before and after an item is sent to the server during
+ the push process.
+
+ *This method is optional*
+ 
+ Called once for each entry on the queue, allowing for any adjustments to the item before it is sent 
+ to the server, or custom handling of the server's response (such as conflict handling).
+ 
+ Errors returned from this function will be collected and passed on as a group to the
+ syncContext:onPushCompleteWithError:completion: method.
+ 
+ Not passing an error when calling the completion block, will cause the code to consider the operation
+ as successful and remove it from the queue. If an item is given that will be stored into the local
+ database.
+ 
+ @param operation gives the pending data (like item id, new values) along with the method to apply
+                  that state to the server
+ @param completion The MSSyncItemBlock block to use to send the results of the operation's execute 
+                   to after applying any custom changes to the item or error.
+ */
 -(void) tableOperation:(nonnull MSTableOperation *)operation onComplete:(nonnull MSSyncItemBlock)completion;
 
-/// Called when all operations that were triggered due to a [pushWithCompletion:] call have completed. If not provided, any
-/// errors will be passed along to the [pushWithCompletion:] call. If provided, errors can be handled and additional changes
-/// may be made to the local or remote database.
--(void) syncContext:(nonnull MSSyncContext *)context onPushCompleteWithError:(nullable NSError *)error completion:(nonnull MSSyncPushCompletionBlock)completion;
-
-/// @}
+/** 
+ This method is called when all operations that were triggered due to a [pushWithCompletion:] call 
+ have completed allowing custom processing to be done before results are returned to the caller.
+ 
+ *This method is optional*
+ 
+ If not provided, any errors will be passed along to the original caller of the push method.
+ 
+ If provided, errors can be handled and additional changes may be made to the local or remote 
+ database.
+ 
+ @param context the MSSyncContext that triggered the push
+ @param error An NSError containing the list of individual errors that occurred during the push
+              process
+ @param completion MSSyncPushCompletionBlock to trigger after all processing is complete. Any
+                   unresolved errors will be passed along to the original push caller
+ */
+-(void) syncContext:(nonnull MSSyncContext *)context
+onPushCompleteWithError:(nullable NSError *)error
+         completion:(nonnull MSSyncPushCompletionBlock)completion;
 
 @end
 
-/// The MSSyncContextDataSource controls how data is stored and retrieved on the device. Errors returned from here will abort
-/// any given sync operation and will be surfaced to the mobile service through push or the delegate.
+/**
+ The MSSyncContextDataSource controls how data is stored and retrieved on the device. Errors returned from here will abort
+ any given sync operation and will be surfaced to the mobile service through push or the delegate.
+ */
 @protocol MSSyncContextDataSource <NSObject>
 
-/// @name Controlling Where Data is Stored
-/// @{
+/** @name Controlling Where Data is Stored */
 
-/// Provides the name of the table to track all table operation meta data
+/** Provides the name of the table to track all table operation meta data */
 - (nonnull NSString *) operationTableName;
 
-/// Provides the name of the table to track all table operation errors until they have been resolved
+/** Provides the name of the table to track all table operation errors until they have been resolved. */
 - (nonnull NSString *) errorTableName;
 
-/// Provides the name of the table to track configuration data
+/** Provides the name of the table to track configuration data */
 - (nonnull NSString *) configTableName;
 
-/// Indicates if the items passed to a sync table call should be saved by the SDK, if disabled, the local store will only
-/// recieve upserts/deletes for data calls originating from the server (pulls & pushes) plus the state tracking on the operation queue.
+/** 
+ Indicates if the items passed to a sync table call should be saved by the SDK, if disabled, the local store will only
+ recieve upserts/deletes for data calls originating from the server (pulls & pushes) plus the state tracking on the operation queue.
+ */
 @property (nonatomic) BOOL handlesSyncTableOperations;
 
-/// @}
+/** @name Fetching and Retrieving Data */
 
-/// @name Fetching and Retrieving Data
-/// @{
+/** 
+ Should returns a result with the array of records matching the constraints specified in the
+ provided query.
+ 
+ @param query the MSQuery to evaluate to determine what records should be returned
+ @param error should be set if an issue occurs while executing the query
+ 
+ @returns An MSSyncContextReadResult with the records matched by the given query
+ */
+- (nullable MSSyncContextReadResult *) readWithQuery:(nullable MSQuery *)query
+                                             orError:(NSError * __nullable * __nullable)error;
 
-/// Returns a dictionary containing the items and totalCount
-- (nullable MSSyncContextReadResult *) readWithQuery:(nullable MSQuery *)query orError:(NSError * __nullable * __nullable)error;
+/**
+ Should retrieve a single item from the local store or nil if item with the given ID does not
+ exist.
+ 
+ @param table the name of the table to get the record from
+ @param itemId the id of the record to look up from the store
+ @param error an NSError if an error occurs looking up the record. Should not be used to indicate
+               the record could not be found.
 
-/// Should retrieve a single item from the local store or nil if item with the given ID does not exist.
--(nullable NSDictionary *) readTable:(nonnull NSString *)table withItemId:(nonnull NSString *)itemId orError:(NSError * __nullable * __nullable)error;
+ @returns item that was found, or nil
+ */
+-(nullable NSDictionary *) readTable:(nonnull NSString *)table
+                          withItemId:(nonnull NSString *)itemId
+                             orError:(NSError * __nullable * __nullable)error;
 
-/// Should insert/update the given item in the local store as appropriate
--(BOOL) upsertItems:(nullable NSArray<NSDictionary *> *)item table:(nonnull NSString *)table orError:(NSError * __nullable * __nullable)error;
+/**
+ Should insert or update the given item(s) in the local store as appropriate
 
-/// Should remove the provided item from the local store
--(BOOL) deleteItemsWithIds:(nonnull NSArray<NSString *> *)items table:(nonnull NSString *)table orError:(NSError * __nullable * __nullable)error;
+ @param items array of item records (represented by an NSDictionary) to add or update in the store
+ @param table the name of the table to add or update the records in
+ @param error an NSError if the requested records cannot be added or updated
+ 
+ @returns boolean indicating if all records were upserted successfully
+ */
+-(BOOL) upsertItems:(nullable NSArray<NSDictionary *> *)items
+              table:(nonnull NSString *)table
+            orError:(NSError * __nullable * __nullable)error;
 
-/// Should remove all entries from the specified table in the local store
-/// @param query query that should be used to find records to be removed
-/// @param error error object to be set in the event an error occurs
-/// @returns Boolean indicating whether the delete was successful
+/**
+ Should delete all records with the provided item ids from the local store. Item Ids that are not
+ in the store should be considered deleted and not cause an error to occur.
+ 
+ @param items array of item ids to delete from the store
+ @param table the name of the table to delete records from
+ @param error an NSError if the requests records failed to be deleted
+ 
+ @returns boolean indicating if all records were deleted
+ */
+-(BOOL) deleteItemsWithIds:(nonnull NSArray<NSString *> *)items
+                     table:(nonnull NSString *)table
+                   orError:(NSError * __nullable * __nullable)error;
+
+/**
+ Should remove all entries returned by the provided query from the specified table in the local
+ store
+
+ @param query query that should be used to find records to be removed
+ @param error error object to be set in the event an error occurs
+ 
+ @returns Boolean indicating whether the delete was successful
+ */
 -(BOOL) deleteUsingQuery:(nonnull MSQuery *)query orError:(NSError * __nullable * __nullable)error;
-
-/// @}
-
-/// @name Controlling system properties in local tables
-/// @{
 
 @optional
 
-/// Returns the MSSystemProperties that have columns in the local database (example: createdAt, updatedAt)
-/// If not implemented, a default of version may be assumed
-/// @param table name of the table to get system properties for
--(NSUInteger) systemPropertiesForTable:(nonnull NSString *)table;
+/** @name Controlling System Properties */
 
-/// @}
+/** 
+ Returns the MSSystemProperties that have columns in the local database (example: createdAt, updatedAt)
+ If not implemented, a default of version may be assumed
+ 
+ *This property is optional*
+ 
+ @param table name of the table to get system properties for
+ 
+ @returns int representing the system properties on the table
+ */
+-(NSUInteger) systemPropertiesForTable:(nonnull NSString *)table;
 
 @end
 
-/// The *MSSyncContext* object controls how offline operations using the *MSSyncTable* object are processed,
-/// stored in local data storage, and sent to the mobile service.
+/** 
+ The MSSyncContext object controls how offline operations using the MSSyncTable are processed,
+ items are stored in local data storage, and how they are sent to the mobile app.
+ */
 @interface MSSyncContext : NSObject
 
-/// @name Initializing the MSSyncContext Object
-/// @{
+/** @name Initializing the MSSyncContext Object */
 
-- (nonnull instancetype) initWithDelegate:(nullable id<MSSyncContextDelegate>)delegate dataSource:(nullable id<MSSyncContextDataSource>) dataSource callback:(nullable NSOperationQueue *)callbackQueue;
+/**
+ Creates a new MSSyncContext using the given delegate, datasource, and callback queue
 
-/// @}
+ @param delegate optional delegate to use to control actions during sync processes
+ @param dataSource optional datasource to use to store items with
+ @param callbackQueue optional queue to use for triggering callbacks related to sync on
 
-/// @name Syncing and Storing Data
-/// @{
+ @returns the crreated MSSyncContext
+ */
+- (nonnull instancetype) initWithDelegate:(nullable id<MSSyncContextDelegate>)delegate
+                               dataSource:(nullable id<MSSyncContextDataSource>) dataSource
+                                 callback:(nullable NSOperationQueue *)callbackQueue;
 
-/// Returns the number of pending outbound operations on the queue
+/** @name Syncing and Storing Data */
+
+/** Returns the number of pending outbound operations on the queue */
 @property (nonatomic, readonly) NSUInteger pendingOperationsCount;
 
-/// Executes all current pending operations on the queue
+/** Executes all current pending operations on the queue */
 - (nonnull NSOperation *) pushWithCompletion:(nullable MSSyncBlock)completion;
 
-/// Specifies the delegate that will be used in the resolution of syncing issues
+/** Specifies the delegate that will be used in the resolution of syncing issues */
 @property (nonatomic, strong, nullable) id<MSSyncContextDelegate> delegate;
 
-/// Specifies the dataSource that owns the local data and store of operations
+/** Specifies the dataSource that owns the local data and store of operations */
 @property (nonatomic, strong, nullable) id<MSSyncContextDataSource> dataSource;
-
-/// @}
 
 @end


### PR DESCRIPTION
Fixes up a handful off the appledoc build warnings by filling out some param and returns values as well as removing some older stylings.  Doing this a couple classes at a time to keep the PRs manageable in size.