### PR TITLE
Offline: Update store to use relationships during upsert

### DIFF
--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -141,6 +141,18 @@
 		A2C14C6A19105D9F00A58609 /* MSSyncContextReadResult.h in Headers */ = {isa = PBXBuildFile; fileRef = A2C14C6819105D9F00A58609 /* MSSyncContextReadResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2C14C6B19105D9F00A58609 /* MSSyncContextReadResult.m in Sources */ = {isa = PBXBuildFile; fileRef = A2C14C6919105D9F00A58609 /* MSSyncContextReadResult.m */; };
 		A319A02A1BD9BA69004D2A49 /* MSTestWaiter.m in Sources */ = {isa = PBXBuildFile; fileRef = CF4D498B1A3253E2006AEB70 /* MSTestWaiter.m */; };
+		A34B54F11C18AB1B00FBD33D /* Customer+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54D91C18AAFC00FBD33D /* Customer+CoreDataProperties.m */; };
+		A34B54F21C18AB1D00FBD33D /* Customer+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54D91C18AAFC00FBD33D /* Customer+CoreDataProperties.m */; };
+		A34B54F31C18AB2500FBD33D /* Customer.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DB1C18AAFC00FBD33D /* Customer.m */; };
+		A34B54F41C18AB2600FBD33D /* Customer.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DB1C18AAFC00FBD33D /* Customer.m */; };
+		A34B54F51C18AB2A00FBD33D /* Item.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DD1C18AAFC00FBD33D /* Item.m */; };
+		A34B54F61C18AB2B00FBD33D /* Item.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DD1C18AAFC00FBD33D /* Item.m */; };
+		A34B54F71C18AB2E00FBD33D /* Item+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DF1C18AAFC00FBD33D /* Item+CoreDataProperties.m */; };
+		A34B54F81C18AB2F00FBD33D /* Item+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54DF1C18AAFC00FBD33D /* Item+CoreDataProperties.m */; };
+		A34B54F91C18AB3700FBD33D /* Order.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54E11C18AAFC00FBD33D /* Order.m */; };
+		A34B54FA1C18AB3800FBD33D /* Order.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54E11C18AAFC00FBD33D /* Order.m */; };
+		A34B54FB1C18AB3B00FBD33D /* Order+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54E31C18AAFC00FBD33D /* Order+CoreDataProperties.m */; };
+		A34B54FC1C18AB3C00FBD33D /* Order+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A34B54E31C18AAFC00FBD33D /* Order+CoreDataProperties.m */; };
 		A3514E3D1BCC62380032B74C /* MSClientConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */; };
 		A3514E3E1BCC64AB0032B74C /* MSClientConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */; };
 		A3D7153A1C1A09EC00545C0B /* MSManagedObjectObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */; };
@@ -439,6 +451,18 @@
 		A2ADF7E81914481B0078BB16 /* MSTableOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTableOperationTests.m; sourceTree = "<group>"; };
 		A2C14C6819105D9F00A58609 /* MSSyncContextReadResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSyncContextReadResult.h; sourceTree = "<group>"; };
 		A2C14C6919105D9F00A58609 /* MSSyncContextReadResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSyncContextReadResult.m; sourceTree = "<group>"; };
+		A34B54D81C18AAFC00FBD33D /* Customer+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Customer+CoreDataProperties.h"; path = "Classes/Customer+CoreDataProperties.h"; sourceTree = "<group>"; };
+		A34B54D91C18AAFC00FBD33D /* Customer+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Customer+CoreDataProperties.m"; path = "Classes/Customer+CoreDataProperties.m"; sourceTree = "<group>"; };
+		A34B54DA1C18AAFC00FBD33D /* Customer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Customer.h; path = Classes/Customer.h; sourceTree = "<group>"; };
+		A34B54DB1C18AAFC00FBD33D /* Customer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Customer.m; path = Classes/Customer.m; sourceTree = "<group>"; };
+		A34B54DC1C18AAFC00FBD33D /* Item.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Item.h; path = Classes/Item.h; sourceTree = "<group>"; };
+		A34B54DD1C18AAFC00FBD33D /* Item.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Item.m; path = Classes/Item.m; sourceTree = "<group>"; };
+		A34B54DE1C18AAFC00FBD33D /* Item+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Item+CoreDataProperties.h"; path = "Classes/Item+CoreDataProperties.h"; sourceTree = "<group>"; };
+		A34B54DF1C18AAFC00FBD33D /* Item+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Item+CoreDataProperties.m"; path = "Classes/Item+CoreDataProperties.m"; sourceTree = "<group>"; };
+		A34B54E01C18AAFC00FBD33D /* Order.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Order.h; path = Classes/Order.h; sourceTree = "<group>"; };
+		A34B54E11C18AAFC00FBD33D /* Order.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Order.m; path = Classes/Order.m; sourceTree = "<group>"; };
+		A34B54E21C18AAFC00FBD33D /* Order+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Order+CoreDataProperties.h"; path = "Classes/Order+CoreDataProperties.h"; sourceTree = "<group>"; };
+		A34B54E31C18AAFC00FBD33D /* Order+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Order+CoreDataProperties.m"; path = "Classes/Order+CoreDataProperties.m"; sourceTree = "<group>"; };
 		A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSClientConnectionTests.m; sourceTree = "<group>"; };
 		A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSManagedObjectObserver.m; sourceTree = "<group>"; };
 		A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSManagedObjectObserver.h; sourceTree = "<group>"; };
@@ -641,6 +665,7 @@
 			isa = PBXGroup;
 			children = (
 				A3D715411C1A0A4200545C0B /* MSManagedObjectObserverTests.m */,
+				A3DEA25A1C18A91F003A24D5 /* Classes */,
 				A295B2B2192AB2040067562E /* MSCoreDataStoreTests.m */,
 				A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */,
 				A29F44A11953CBF30063C0C1 /* MSCoreDataStore+TestHelper.h */,
@@ -692,6 +717,25 @@
 				A214410B182631A500C2E762 /* MSTableFuncTests.m */,
 			);
 			name = Functional;
+			sourceTree = "<group>";
+		};
+		A3DEA25A1C18A91F003A24D5 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				A34B54D81C18AAFC00FBD33D /* Customer+CoreDataProperties.h */,
+				A34B54D91C18AAFC00FBD33D /* Customer+CoreDataProperties.m */,
+				A34B54DA1C18AAFC00FBD33D /* Customer.h */,
+				A34B54DB1C18AAFC00FBD33D /* Customer.m */,
+				A34B54DC1C18AAFC00FBD33D /* Item.h */,
+				A34B54DD1C18AAFC00FBD33D /* Item.m */,
+				A34B54DE1C18AAFC00FBD33D /* Item+CoreDataProperties.h */,
+				A34B54DF1C18AAFC00FBD33D /* Item+CoreDataProperties.m */,
+				A34B54E01C18AAFC00FBD33D /* Order.h */,
+				A34B54E11C18AAFC00FBD33D /* Order.m */,
+				A34B54E21C18AAFC00FBD33D /* Order+CoreDataProperties.h */,
+				A34B54E31C18AAFC00FBD33D /* Order+CoreDataProperties.m */,
+			);
+			name = Classes;
 			sourceTree = "<group>";
 		};
 		E84CA4E016272BA2009B2588 /* Login */ = {
@@ -1386,11 +1430,16 @@
 				E8F33B3F1616695E002DD7C6 /* MSPredicateTranslatorTests.m in Sources */,
 				A2ADF7E91914481B0078BB16 /* MSTableOperationTests.m in Sources */,
 				A258891E18A1A30000962F9A /* MSSyncTableTests.m in Sources */,
+				A34B54F51C18AB2A00FBD33D /* Item.m in Sources */,
+				A34B54FB1C18AB3B00FBD33D /* Order+CoreDataProperties.m in Sources */,
 				E87BB01C161A28FC008053F9 /* MSClientTests.m in Sources */,
+				A34B54F11C18AB1B00FBD33D /* Customer+CoreDataProperties.m in Sources */,
 				E87BB022161B57C8008053F9 /* MSUserTests.m in Sources */,
 				E87BB025161B5A4D008053F9 /* MSTableTests.m in Sources */,
 				A3514E3D1BCC62380032B74C /* MSClientConnectionTests.m in Sources */,
 				E8EA24C0161CFCF400BE055D /* MSURLbuilderTests.m in Sources */,
+				A34B54F91C18AB3700FBD33D /* Order.m in Sources */,
+				A34B54F71C18AB2E00FBD33D /* Item+CoreDataProperties.m in Sources */,
 				A24701C6196897A700385DA2 /* MSPushTests.m in Sources */,
 				A28224B3192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld in Sources */,
 				E8E37904161E2FC500C13F00 /* MSTestFilter.m in Sources */,
@@ -1401,6 +1450,7 @@
 				A295B2B3192AB2040067562E /* MSCoreDataStoreTests.m in Sources */,
 				A29F44A31953CBF30063C0C1 /* MSCoreDataStore+TestHelper.m in Sources */,
 				E84CA4D6162373E2009B2588 /* MSUserAgentBuilderTests.m in Sources */,
+				A34B54F31C18AB2500FBD33D /* Customer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1463,11 +1513,16 @@
 				F3EBDFFF1BAC311D00D82B10 /* MSTableFuncTests.m in Sources */,
 				F3EBE0001BAC311D00D82B10 /* MSClientTests.m in Sources */,
 				F3EBE0011BAC311D00D82B10 /* MSFilterTest.m in Sources */,
+				A34B54F61C18AB2B00FBD33D /* Item.m in Sources */,
+				A34B54FC1C18AB3C00FBD33D /* Order+CoreDataProperties.m in Sources */,
 				F3EBE0021BAC311D00D82B10 /* MSQueryTests.m in Sources */,
+				A34B54F21C18AB1D00FBD33D /* Customer+CoreDataProperties.m in Sources */,
 				F3EBE0031BAC311D00D82B10 /* MSTableTests.m in Sources */,
 				F3EBE0041BAC311D00D82B10 /* MSTestWaiter.m in Sources */,
 				F3EBE0051BAC311D00D82B10 /* MSUserTests.m in Sources */,
 				F3EBE0061BAC311D00D82B10 /* MSCoreDataStoreTests.m in Sources */,
+				A34B54FA1C18AB3800FBD33D /* Order.m in Sources */,
+				A34B54F81C18AB2F00FBD33D /* Item+CoreDataProperties.m in Sources */,
 				F3EBE0071BAC311D00D82B10 /* MSCoreDataStore+TestHelper.m in Sources */,
 				F3EBE0081BAC311D00D82B10 /* TodoItem.m in Sources */,
 				F3EBE0091BAC311D00D82B10 /* MSTableOperationTests.m in Sources */,
@@ -1478,6 +1533,7 @@
 				F3EBE00E1BAC311D00D82B10 /* MSPushTests.m in Sources */,
 				F3EBE00F1BAC311D00D82B10 /* MSPredicateTranslatorTests.m in Sources */,
 				F3EBE0101BAC311D00D82B10 /* MSJSONSerializerTests.m in Sources */,
+				A34B54F41C18AB2600FBD33D /* Customer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sdk/src/MSCoreDataStore.h
+++ b/sdk/src/MSCoreDataStore.h
@@ -57,5 +57,13 @@
  */
 -(nonnull NSDictionary *) tableItemFromManagedObject:(nonnull NSManagedObject *)object;
 
+/** 
+ If set, during an upsert (From server or locally) any relationship properties on the table
+ will be looked at, and if data is present will be added to that related table. If set explictly
+ to null, that record will be deleted.  If nil, the property will be ignored.
+ 
+ When false (default) any value in a relationship property will just be ignored during the upsert.
+ */
+@property (nonatomic) bool expandRelationshipsOnUpsert;
 
 @end

--- a/sdk/test/Classes/Customer+CoreDataProperties.h
+++ b/sdk/test/Classes/Customer+CoreDataProperties.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Customer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Customer (CoreDataProperties)
+
+@property (nullable, nonatomic, retain) NSString *id;
+@property (nullable, nonatomic, retain) NSString *name;
+@property (nullable, nonatomic, retain) NSString *phone;
+@property (nullable, nonatomic, retain) NSSet<Order *> *orders;
+
+@end
+
+@interface Customer (CoreDataGeneratedAccessors)
+
+- (void)addOrdersObject:(Order *)value;
+- (void)removeOrdersObject:(Order *)value;
+- (void)addOrders:(NSSet<Order *> *)values;
+- (void)removeOrders:(NSSet<Order *> *)values;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/test/Classes/Customer+CoreDataProperties.m
+++ b/sdk/test/Classes/Customer+CoreDataProperties.m
@@ -1,0 +1,18 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Customer+CoreDataProperties.h"
+
+@implementation Customer (CoreDataProperties)
+
+@dynamic id;
+@dynamic name;
+@dynamic phone;
+@dynamic orders;
+
+@end

--- a/sdk/test/Classes/Customer.h
+++ b/sdk/test/Classes/Customer.h
@@ -1,0 +1,24 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Order;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Customer : NSManagedObject
+
+// Insert code here to declare functionality of your managed object subclass
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#import "Customer+CoreDataProperties.h"

--- a/sdk/test/Classes/Customer.m
+++ b/sdk/test/Classes/Customer.m
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Customer.h"
+#import "Order.h"
+
+@implementation Customer
+
+// Insert code here to add functionality to your managed object subclass
+
+@end

--- a/sdk/test/Classes/Item+CoreDataProperties.h
+++ b/sdk/test/Classes/Item+CoreDataProperties.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Item.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Item (CoreDataProperties)
+
+@property (nullable, nonatomic, retain) NSString *id;
+@property (nullable, nonatomic, retain) NSString *name;
+@property (nullable, nonatomic, retain) NSNumber *price;
+@property (nullable, nonatomic, retain) NSSet<Order *> *orders;
+
+@end
+
+@interface Item (CoreDataGeneratedAccessors)
+
+- (void)addOrdersObject:(Order *)value;
+- (void)removeOrdersObject:(Order *)value;
+- (void)addOrders:(NSSet<Order *> *)values;
+- (void)removeOrders:(NSSet<Order *> *)values;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/test/Classes/Item+CoreDataProperties.m
+++ b/sdk/test/Classes/Item+CoreDataProperties.m
@@ -1,0 +1,18 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Item+CoreDataProperties.h"
+
+@implementation Item (CoreDataProperties)
+
+@dynamic id;
+@dynamic name;
+@dynamic price;
+@dynamic orders;
+
+@end

--- a/sdk/test/Classes/Item.h
+++ b/sdk/test/Classes/Item.h
@@ -1,0 +1,24 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class Order;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Item : NSManagedObject
+
+// Insert code here to declare functionality of your managed object subclass
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#import "Item+CoreDataProperties.h"

--- a/sdk/test/Classes/Item.m
+++ b/sdk/test/Classes/Item.m
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Item.h"
+#import "Order.h"
+
+@implementation Item
+
+// Insert code here to add functionality to your managed object subclass
+
+@end

--- a/sdk/test/Classes/Order+CoreDataProperties.h
+++ b/sdk/test/Classes/Order+CoreDataProperties.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Order.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Order (CoreDataProperties)
+
+@property (nullable, nonatomic, retain) NSString *id;
+@property (nullable, nonatomic, retain) NSString *name;
+@property (nullable, nonatomic, retain) NSManagedObject *customer;
+@property (nullable, nonatomic, retain) NSSet<NSManagedObject *> *items;
+
+@end
+
+@interface Order (CoreDataGeneratedAccessors)
+
+- (void)addItemsObject:(NSManagedObject *)value;
+- (void)removeItemsObject:(NSManagedObject *)value;
+- (void)addItems:(NSSet<NSManagedObject *> *)values;
+- (void)removeItems:(NSSet<NSManagedObject *> *)values;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/test/Classes/Order+CoreDataProperties.m
+++ b/sdk/test/Classes/Order+CoreDataProperties.m
@@ -1,0 +1,18 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Order+CoreDataProperties.h"
+
+@implementation Order (CoreDataProperties)
+
+@dynamic id;
+@dynamic name;
+@dynamic customer;
+@dynamic items;
+
+@end

--- a/sdk/test/Classes/Order.h
+++ b/sdk/test/Classes/Order.h
@@ -1,0 +1,22 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Order : NSManagedObject
+
+// Insert code here to declare functionality of your managed object subclass
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#import "Order+CoreDataProperties.h"

--- a/sdk/test/Classes/Order.m
+++ b/sdk/test/Classes/Order.m
@@ -1,0 +1,15 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "Order.h"
+
+@implementation Order
+
+// Insert code here to add functionality to your managed object subclass
+
+@end

--- a/sdk/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
+++ b/sdk/test/CoreDataTestModel.xcdatamodeld/CoreDataTestModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="8195" systemVersion="15A284" minimumToolsVersion="Xcode 4.3">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 4.3">
     <entity name="Child" representedClassName="Child" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="value" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
@@ -17,6 +17,18 @@
         <attribute name="int32" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="int64" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="string" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Customer" representedClassName="Customer" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="phone" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Order" inverseName="customer" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="Item" representedClassName="Item" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
     </entity>
     <entity name="ManySystemColumns" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -47,6 +59,12 @@
         <attribute name="table" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="tableKind" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
     </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="customer" maxCount="1" deletionRule="Nullify" destinationEntity="Customer" inverseName="orders" inverseEntity="Customer" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Item" inverseName="orders" inverseEntity="Item" syncable="YES"/>
+    </entity>
     <entity name="Parent" representedClassName="Parent" syncable="YES">
         <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -65,10 +83,13 @@
     <elements>
         <element name="Child" positionX="-90" positionY="-9" width="128" height="90"/>
         <element name="ColumnTypes" positionX="-54" positionY="54" width="128" height="210"/>
+        <element name="Customer" positionX="-99" positionY="-18" width="128" height="105"/>
+        <element name="Item" positionX="-108" positionY="-27" width="128" height="105"/>
         <element name="ManySystemColumns" positionX="-252" positionY="27" width="128" height="150"/>
         <element name="MS_TableConfig" positionX="160" positionY="192" width="128" height="118"/>
         <element name="MS_TableOperationErrors" positionX="153" positionY="-189" width="128" height="103"/>
         <element name="MS_TableOperations" positionX="-63" positionY="-189" width="128" height="118"/>
+        <element name="Order" positionX="-117" positionY="-36" width="128" height="105"/>
         <element name="Parent" positionX="-99" positionY="-18" width="128" height="90"/>
         <element name="TodoItem" positionX="-324" positionY="-45" width="128" height="105"/>
         <element name="TodoNoVersion" positionX="-234" positionY="-126" width="128" height="73"/>

--- a/sdk/test/MSCoreDataStoreTests.m
+++ b/sdk/test/MSCoreDataStoreTests.m
@@ -265,6 +265,7 @@ static NSString *const TableName = @"TodoItem";
 {
     NSError *error;
     NSDictionary *originalItem = @{ @"id" : @"A", @"name" : @"test1", @"child" : @"123" };
+    self.store.expandRelationshipsOnUpsert = YES;
     
     [self.store upsertItems:@[originalItem] table:@"Parent" orError:&error];
     XCTAssertNil(error, @"upsert failed: %@", error.description);
@@ -279,6 +280,7 @@ static NSString *const TableName = @"TodoItem";
 -(void)testUpsert_Relationships_NewRecords_Success
 {
     NSError *error;
+    self.store.expandRelationshipsOnUpsert = YES;
     
     [self populateDefaultParentChild];
     
@@ -313,6 +315,8 @@ static NSString *const TableName = @"TodoItem";
                                        }
                                }
                            ];
+    
+    self.store.expandRelationshipsOnUpsert = YES;
     
     // Put a base child record into the store
     [self.store upsertItems:@[ @{ @"id": @"C_1", @"value" : @10 } ]
@@ -352,6 +356,8 @@ static NSString *const TableName = @"TodoItem";
         @"child": @{ @"id": @"C_1", @"value" : @14 }
     } ];
     
+    self.store.expandRelationshipsOnUpsert = YES;
+    
     // Put the record we are updating into the store
     [self.store upsertItems:@[ @{ @"id": @"P_1", @"name" : @"ParentA" } ]
                       table:@"Parent"
@@ -384,6 +390,8 @@ static NSString *const TableName = @"TodoItem";
 {
     NSError *error;
     
+    self.store.expandRelationshipsOnUpsert = YES;
+    
     [self populateDefaultParentChild];
     
     // Update just the parent record
@@ -410,6 +418,8 @@ static NSString *const TableName = @"TodoItem";
 -(void)testUpsert_Relationships_RemoveExistingRelationship_Success
 {
     NSError *error;
+    self.store.expandRelationshipsOnUpsert = YES;
+    
     [self populateDefaultParentChild];
     
     // Seperate the relationship now
@@ -436,6 +446,8 @@ static NSString *const TableName = @"TodoItem";
 -(void)testUpsert_Relationships_ManyToMany_Success
 {
     NSError *error;
+    self.store.expandRelationshipsOnUpsert = YES;
+    
     NSArray *testOrders = @[ @{
         @"id" : @"O-1",
         @"customer" : @{ @"id" : @"C-1", @"name" : @"Fred" },


### PR DESCRIPTION
This adds the ability for the MSCoreDataStore to start understanding relationship attributes during upsert requests.   This allows, a server (Via use of $expand oData querystring) to sync a table's required relationships during Pulls.

So for example, an order can contain a to many relationship with a lineitem, like { id: 'x', lineItems: [ { id: 1  }, {id: 2 }], and the store will insert both the Order 'X' and LineItems '1', '2' together in the same save.  

Notes: 
- while you can do the same via a SyncTable call, a tracking operation will only be made for the root table (so not recommended, unless you also add custom push logic)
