### PR TITLE
Offline: Restore managed object observer class

### DIFF
--- a/MicrosoftAzureMobile.podspec
+++ b/MicrosoftAzureMobile.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
     "sdk/src/MSError.h",
     "sdk/src/MSFilter.h",
     "sdk/src/MSLoginController.h",
+    "sdk/src/MSManagedObjectObserver.h",
     "sdk/src/MSPullSettings.h",
     "sdk/src/MSPush.h",
     "sdk/src/MSQuery.h",

--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -143,6 +143,14 @@
 		A319A02A1BD9BA69004D2A49 /* MSTestWaiter.m in Sources */ = {isa = PBXBuildFile; fileRef = CF4D498B1A3253E2006AEB70 /* MSTestWaiter.m */; };
 		A3514E3D1BCC62380032B74C /* MSClientConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */; };
 		A3514E3E1BCC64AB0032B74C /* MSClientConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */; };
+		A3D7153A1C1A09EC00545C0B /* MSManagedObjectObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */; };
+		A3D7153C1C1A09F300545C0B /* MSManagedObjectObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3D7153D1C1A09FE00545C0B /* MSManagedObjectObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3D7153E1C1A09FE00545C0B /* MSManagedObjectObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3D7153F1C1A0A0600545C0B /* MSManagedObjectObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */; };
+		A3D715401C1A0A0700545C0B /* MSManagedObjectObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */; };
+		A3D715431C1A0CD100545C0B /* MSManagedObjectObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715411C1A0A4200545C0B /* MSManagedObjectObserverTests.m */; };
+		A3D715441C1A0CD200545C0B /* MSManagedObjectObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3D715411C1A0A4200545C0B /* MSManagedObjectObserverTests.m */; };
 		A3FD2DB01BB1C3F300624DA0 /* MSQueryInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8790D2BF199EA5950000DC4E /* MSQueryInternal.h */; };
 		A3FD2DB11BB1C3FA00624DA0 /* MSTableInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8790D2BE199C5D510000DC4E /* MSTableInternal.h */; };
 		A3FD2DB21BB1C40900624DA0 /* MSPullSettingsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D0EFD8581B2F785F009CF6DA /* MSPullSettingsInternal.h */; };
@@ -432,6 +440,9 @@
 		A2C14C6819105D9F00A58609 /* MSSyncContextReadResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSyncContextReadResult.h; sourceTree = "<group>"; };
 		A2C14C6919105D9F00A58609 /* MSSyncContextReadResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSyncContextReadResult.m; sourceTree = "<group>"; };
 		A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSClientConnectionTests.m; sourceTree = "<group>"; };
+		A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSManagedObjectObserver.m; sourceTree = "<group>"; };
+		A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSManagedObjectObserver.h; sourceTree = "<group>"; };
+		A3D715411C1A0A4200545C0B /* MSManagedObjectObserverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSManagedObjectObserverTests.m; sourceTree = "<group>"; };
 		CF1D74581A5D85C60074789F /* MSQueuePurgeOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSQueuePurgeOperation.m; sourceTree = "<group>"; };
 		CF1D745A1A5D85D80074789F /* MSQueuePurgeOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQueuePurgeOperation.h; sourceTree = "<group>"; };
 		CF4D49851A2E5C96006AEB70 /* MSQueuePullOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSQueuePullOperation.h; sourceTree = "<group>"; };
@@ -629,6 +640,7 @@
 		A295B2B1192AB1DC0067562E /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				A3D715411C1A0A4200545C0B /* MSManagedObjectObserverTests.m */,
 				A295B2B2192AB2040067562E /* MSCoreDataStoreTests.m */,
 				A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */,
 				A29F44A11953CBF30063C0C1 /* MSCoreDataStore+TestHelper.h */,
@@ -642,6 +654,8 @@
 		A2ACD539192322760012B1ED /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				A3D7153B1C1A09F300545C0B /* MSManagedObjectObserver.h */,
+				A3D715391C1A09EC00545C0B /* MSManagedObjectObserver.m */,
 				A2ACD53E192322C50012B1ED /* MSCoreDataStore.h */,
 				A2ACD53F192322C50012B1ED /* MSCoreDataStore.m */,
 			);
@@ -900,6 +914,7 @@
 				5A4FAC801B05E4A30027011D /* MSTableOperationInternal.h in Headers */,
 				5A4FAC9E1B05E56A0027011D /* MSSyncContextReadResult.h in Headers */,
 				5A4FAC8D1B05E5180027011D /* MSTable.h in Headers */,
+				A3D7153D1C1A09FE00545C0B /* MSManagedObjectObserver.h in Headers */,
 				5A4FAC891B05E4FE0027011D /* MSError.h in Headers */,
 				5A4FACA61B05E6000027011D /* MSQueuePullOperation.h in Headers */,
 				5A4FAC851B05E4E90027011D /* MSClient.h in Headers */,
@@ -955,6 +970,7 @@
 				E8E3790D161F769D00C13F00 /* MicrosoftAzureMobile.h in Headers */,
 				E84CA4E116272C15009B2588 /* MSLoginController.h in Headers */,
 				E8E3790E161F769D00C13F00 /* MSClient.h in Headers */,
+				A3D7153C1C1A09F300545C0B /* MSManagedObjectObserver.h in Headers */,
 				E8E37911161F769D00C13F00 /* MSTable.h in Headers */,
 				A24701BD196896F500385DA2 /* MSPushRequest.h in Headers */,
 				A3FD2DB01BB1C3F300624DA0 /* MSQueryInternal.h in Headers */,
@@ -1011,6 +1027,7 @@
 				F3C0027D1AF7FFF60028AB81 /* MSQuery.h in Headers */,
 				F3C0027F1AF7FFF60028AB81 /* MSTable.h in Headers */,
 				F3C002811AF7FFF60028AB81 /* MSUser.h in Headers */,
+				A3D7153E1C1A09FE00545C0B /* MSManagedObjectObserver.h in Headers */,
 				F3C002831AF7FFF60028AB81 /* MSPush.h in Headers */,
 				F3C002791AF7FFF60028AB81 /* MSClient.h in Headers */,
 				F3C0027B1AF7FFF60028AB81 /* MSDateOffset.h in Headers */,
@@ -1281,6 +1298,7 @@
 				5A4FAC7C1B05E4910027011D /* MSLoginView.m in Sources */,
 				5A4FAC901B05E52C0027011D /* MSUser.m in Sources */,
 				5A4FACBD1B05E6700027011D /* MSSDKFeatures.m in Sources */,
+				A3D7153F1C1A0A0600545C0B /* MSManagedObjectObserver.m in Sources */,
 				5A4FACC11B05E67E0027011D /* MSUserAgentBuilder.m in Sources */,
 				5A4FACAB1B05E6160027011D /* MSQueuePushOperation.m in Sources */,
 				5A4FACAF1B05E6280027011D /* MSTableOperation.m in Sources */,
@@ -1325,6 +1343,7 @@
 				E8F33B2416166822002DD7C6 /* MSClientConnection.m in Sources */,
 				A202C3471AA25F730005A8AE /* MSPushConnection.m in Sources */,
 				870C0C9D199C246700A134DD /* MSSDKFeatures.m in Sources */,
+				A3D7153A1C1A09EC00545C0B /* MSManagedObjectObserver.m in Sources */,
 				A281900518BB2FF5001B14E7 /* MSTableOperationError.m in Sources */,
 				E8F33B2516166822002DD7C6 /* MSTableConnection.m in Sources */,
 				E8F33B2616166822002DD7C6 /* MSTableRequest.m in Sources */,
@@ -1361,6 +1380,7 @@
 				A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */,
 				A232CCA21AC8FDE800E15D3A /* MSTableOperationErrorTests.m in Sources */,
 				E8F33B3D1616694C002DD7C6 /* MSQueryTests.m in Sources */,
+				A3D715431C1A0CD100545C0B /* MSManagedObjectObserverTests.m in Sources */,
 				E8F33B3E16166956002DD7C6 /* MSJSONSerializerTests.m in Sources */,
 				A258891F18A1A30500962F9A /* MSOfflinePassthroughHelper.m in Sources */,
 				E8F33B3F1616695E002DD7C6 /* MSPredicateTranslatorTests.m in Sources */,
@@ -1408,6 +1428,7 @@
 				F3C002641AF7FFD10028AB81 /* MSQueuePushOperation.m in Sources */,
 				F3C002651AF7FFD20028AB81 /* MSTableConfigValue.m in Sources */,
 				F3C002661AF7FFD20028AB81 /* MSTableOperation.m in Sources */,
+				A3D715401C1A0A0700545C0B /* MSManagedObjectObserver.m in Sources */,
 				F3C002671AF7FFD20028AB81 /* MSTableOperationError.m in Sources */,
 				F3C0026A1AF7FFD20028AB81 /* MSLogin.m in Sources */,
 				F3C0026B1AF7FFD20028AB81 /* MSLoginSerializer.m in Sources */,
@@ -1436,6 +1457,7 @@
 				F3EBDFFB1BAC311D00D82B10 /* MSUserAgentBuilderTests.m in Sources */,
 				A3514E3E1BCC64AB0032B74C /* MSClientConnectionTests.m in Sources */,
 				F3EBDFFC1BAC311D00D82B10 /* MSMultiRequestTestFilter.m in Sources */,
+				A3D715441C1A0CD200545C0B /* MSManagedObjectObserverTests.m in Sources */,
 				F3EBDFFD1BAC311D00D82B10 /* MSTestFilter.m in Sources */,
 				F3EBDFFE1BAC311D00D82B10 /* MSTable+MSTableTestUtilities.m in Sources */,
 				F3EBDFFF1BAC311D00D82B10 /* MSTableFuncTests.m in Sources */,

--- a/sdk/src/MSCoreDataStore.h
+++ b/sdk/src/MSCoreDataStore.h
@@ -31,6 +31,9 @@
 /// code is working directly with NSManagedObjects.
 @property (nonatomic) BOOL handlesSyncTableOperations;
 
+/// The NSManagedObjectContext that is associated with this data store
+@property (readonly, nonatomic, nonnull, strong) NSManagedObjectContext *context;
+
 #pragma mark * Helper functions
 
 /// @{name Working with the table APIs

--- a/sdk/src/MSCoreDataStore.m
+++ b/sdk/src/MSCoreDataStore.m
@@ -19,8 +19,8 @@
 {
     self = [super init];
     if (self) {
-        self.context = context;
-		self.handlesSyncTableOperations = YES;
+        _context = context;
+		_handlesSyncTableOperations = YES;
     }
     return self;
 }

--- a/sdk/src/MSManagedObjectObserver.h
+++ b/sdk/src/MSManagedObjectObserver.h
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+#import "MSTableOperation.h"
+
+typedef void (^MSManagedObjectObserverCompletionBlock)(MSTableOperationTypes operationType,
+                                                       NSDictionary *item,
+                                                       NSError *error);
+
+@class MSClient;
+
+@interface MSManagedObjectObserver : NSObject
+
+/// The MSCoreDataStore class is for use when using the offline capabilities
+/// of mobile services. This class is a local store which manages records and sync
+/// logic using CoreData.
+
+- (instancetype) initWithClient:(MSClient *)client context:(NSManagedObjectContext *)context;
+
+/// Block to be called on each operation that will is inserted into MS_TableOperations
+///
+/// If not implemented or not dealing with errors and errors occur during these operations
+/// the local store and associated messages to the mobile services API will be left
+/// in a bad state.
+@property (nonatomic, copy) MSManagedObjectObserverCompletionBlock observerActionCompleted;
+
+@end

--- a/sdk/src/MSManagedObjectObserver.m
+++ b/sdk/src/MSManagedObjectObserver.m
@@ -1,0 +1,128 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import "MSManagedObjectObserver.h"
+#import "MSCoreDataStore.h"
+#import "MSClient.h"
+#import "MSSyncTable.h"
+#import <CoreData/CoreData.h>
+
+@interface MSManagedObjectObserver()
+
+@property (nonatomic, strong) MSClient *client;
+@property (nonatomic, weak) NSManagedObjectContext *context;
+@property (nonatomic, weak) MSCoreDataStore *store;
+
+@end
+
+@implementation MSManagedObjectObserver
+
+- (instancetype) initWithClient:(MSClient *)client context:(NSManagedObjectContext *)context
+{
+    self = [super init];
+    
+    NSAssert(context != nil, @"context may not be nil");
+    
+    if (self) {
+        if (![client.syncContext.dataSource isKindOfClass:[MSCoreDataStore class]]) {
+            // Throw error
+            return nil;
+        }
+        
+        _store = client.syncContext.dataSource;
+        NSAssert(_store.context != context, @"Observed context may not be the client's context");
+        
+        _client = client;
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleDidSaveNotification:)
+                                                     name:NSManagedObjectContextDidSaveNotification
+                                                   object:context];
+        
+		// Modify the handling of sync table operations for this instance of the data source
+		_client.syncContext.dataSource.handlesSyncTableOperations = NO;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+	if (self.context != nil)
+	{
+		[[NSNotificationCenter defaultCenter] removeObserver:self
+														name:NSManagedObjectContextDidSaveNotification
+													  object:self.context];
+	}
+}
+
+/// Checks the entity has the ms_version attribute to signal it should
+/// be synchronised to the mobile service
+- (BOOL)entityHasRemoteStoreAttributes:(NSManagedObject *)managedObject
+{
+	return (managedObject.entity.attributesByName[@"version"] != nil);
+}
+
+- (void)handleDidSaveNotification:(NSNotification *)notification
+{
+	NSSet *insertedObjects = notification.userInfo[NSInsertedObjectsKey];
+	for (NSManagedObject *insertedObject in insertedObjects)
+	{
+		if (![self entityHasRemoteStoreAttributes:insertedObject]) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = insertedObject.entity.name;
+        NSDictionary *tableItem = [self.store tableItemFromManagedObject:insertedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable insert:tableItem completion:^(NSDictionary *item, NSError *error) {
+			if (self.observerActionCompleted != nil)
+			{
+				self.observerActionCompleted(MSTableOperationInsert, tableItem, error);
+			}
+		}];
+	}
+	
+	NSSet *updatedObjects = notification.userInfo[NSUpdatedObjectsKey];
+	for (NSManagedObject *updatedObject in updatedObjects)
+	{
+		if (![self entityHasRemoteStoreAttributes:updatedObject]) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = updatedObject.entity.name;
+        NSDictionary *tableItem = [self.store tableItemFromManagedObject:updatedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable update:tableItem completion:^(NSError *error) {
+			if (self.observerActionCompleted != nil)
+			{
+				self.observerActionCompleted(MSTableOperationUpdate, tableItem, error);
+			}
+		}];
+	}
+	
+	NSSet *deletedObjects = notification.userInfo[NSDeletedObjectsKey];
+	for (NSManagedObject *deletedObject in deletedObjects)
+	{
+		if (![self entityHasRemoteStoreAttributes:deletedObject]) {
+			// Only apply table operations on entities we expect to be managed by the mobile service
+			continue;
+		}
+		
+		NSString *tableName = deletedObject.entity.name;
+		NSDictionary *tableItem = [self.store tableItemFromManagedObject:deletedObject];
+		
+		MSSyncTable *syncTable = [self.client syncTableWithName:tableName];
+		[syncTable delete:tableItem completion:^(NSError *error) {
+			if (self.observerActionCompleted != nil)
+			{
+				self.observerActionCompleted(MSTableOperationDelete, tableItem, error);
+			}
+		}];
+	}
+}
+
+@end

--- a/sdk/src/MicrosoftAzureMobile.h
+++ b/sdk/src/MicrosoftAzureMobile.h
@@ -14,6 +14,7 @@
 #if TARGET_OS_IPHONE
 #import "MSLoginController.h"
 #endif
+#import "MSManagedObjectObserver.h"
 #import "MSPullSettings.h"
 #import "MSPush.h"
 #import "MSQuery.h"
@@ -27,7 +28,7 @@
 #import "MSUser.h"
 
 #define MicrosoftAzureMobileSdkMajorVersion 3
-#define MicrosoftAzureMobileSdkMinorVersion 0
+#define MicrosoftAzureMobileSdkMinorVersion 1
 #define MicrosoftAzureMobileSdkBuildVersion 0
 
 #endif

--- a/sdk/test/MSCoreDataStoreTests.m
+++ b/sdk/test/MSCoreDataStoreTests.m
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-
 #import <XCTest/XCTest.h>
 #import "MSCoreDataStore.h"
 #import "MSCoreDataStore+TestHelper.h"

--- a/sdk/test/MSManagedObjectObserverTests.m
+++ b/sdk/test/MSManagedObjectObserverTests.m
@@ -1,0 +1,231 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSCoreDataStore.h"
+#import "MSCoreDataStore+TestHelper.h"
+#import "MSJSONSerializer.h"
+#import "TodoItem.h"
+#import "MSManagedObjectObserver.h"
+#import "MSTableOperation.h"
+
+@interface MSManagedObjectObserverTests : XCTestCase
+@property (nonatomic, strong) MSClient *client;
+@property (nonatomic, strong) MSCoreDataStore *store;
+@property (nonatomic, strong) NSManagedObjectContext *context;
+@property (nonatomic, strong) NSManagedObjectContext *storeContext;
+@property (nonatomic, strong) MSManagedObjectObserver *observer;
+
+@property (nonatomic, strong) TodoItem *item;
+@end
+
+@implementation MSManagedObjectObserverTests
+
+/// Helper method so we can start observing at the point we want to rather than initialized during setup
+- (void)startObservingContextWithObservationCompletion:(MSManagedObjectObserverCompletionBlock)completionBlock
+{
+    self.observer = [[MSManagedObjectObserver alloc] initWithClient:self.client context: self.context];
+	self.observer.observerActionCompleted = completionBlock;
+}
+
+- (void)insertTestItem
+{
+	self.item = [NSEntityDescription insertNewObjectForEntityForName:@"TodoItem" inManagedObjectContext:self.context];
+	
+	self.item.text = @"Test item";
+	self.item.id = @"ABC";
+	
+	[self.context save:nil];
+}
+
+- (void)setUp
+{
+    [super setUp];
+	
+	self.context = [MSCoreDataStore inMemoryManagedObjectContext];
+    self.storeContext = [MSCoreDataStore inMemoryManagedObjectContext];
+    
+    self.store = [[MSCoreDataStore alloc] initWithManagedObjectContext:self.storeContext];
+	
+    self.client = [MSClient clientWithApplicationURLString:@"https://test.com"];
+	self.client.syncContext = [[MSSyncContext alloc] initWithDelegate:nil dataSource:self.store callback:nil];
+}
+
+- (void)tearDown
+{
+	self.store = nil;
+	
+    [super tearDown];
+}
+
+- (void)testObservingInsertOperation
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Table operation observed"];
+	
+	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
+		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
+		
+		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
+		
+		NSManagedObject *tableOperation = tableOperations.firstObject;
+		NSString *operationTable = [tableOperation valueForKey:@"table"];
+		XCTAssertEqualObjects(operationTable, self.item.entity.name, @"The operation should be associated for the %@ table", self.item.entity.name);
+		
+		NSString *operationItemId = [tableOperation valueForKey:@"itemId"];
+		XCTAssertEqualObjects(operationItemId, self.item.id, @"The operation should be associated for the inserted item with id %@", self.item.id);
+		
+		NSDictionary *properties = [[MSJSONSerializer JSONSerializer] itemFromData:[tableOperation valueForKey:@"properties"] withOriginalItem:nil ensureDictionary:YES orError:nil];
+		
+		XCTAssertEqual([properties[@"type"] integerValue], MSTableOperationInsert, @"Associated operation should be an insert with newly created object");
+		
+		[expectation fulfill];
+	}];
+	
+	[self insertTestItem];
+	
+	[self waitForExpectationsWithTimeout:3 handler:^(NSError *error) {
+		if (error != nil)
+		{
+			XCTFail(@"Expectation for observer save failed");
+		}
+	}];
+}
+
+- (void)testObservingUpdateOperation
+{
+	[self insertTestItem];
+	
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Update object expectation"];
+	
+	// Start observing after insert as we are only concerned about subsequent updates
+	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
+		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
+		
+		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
+		
+		NSManagedObject *tableOperation = tableOperations.firstObject;
+		NSString *operationTable = [tableOperation valueForKey:@"table"];
+		XCTAssertEqualObjects(operationTable, self.item.entity.name, @"The operation should be associated for the %@ table", self.item.entity.name);
+		
+		NSString *operationItemId = [tableOperation valueForKey:@"itemId"];
+		XCTAssertEqualObjects(operationItemId, self.item.id, @"The operation should be associated for the inserted item with id %@", self.item.id);
+		
+		NSDictionary *properties = [[MSJSONSerializer JSONSerializer] itemFromData:[tableOperation valueForKey:@"properties"] withOriginalItem:nil ensureDictionary:YES orError:nil];
+		
+		XCTAssertEqual([properties[@"type"] integerValue], MSTableOperationUpdate, @"Associated operation should be an insert with newly created object");
+		
+		[expectation fulfill];
+	}];
+	
+	self.item.text = @"Test item updated";
+	[self.context save:nil];
+	
+	[self waitForExpectationsWithTimeout:3 handler:^(NSError *error) {
+		if (error != nil)
+		{
+			XCTFail(@"Failed to perform update operation in 3 seconds");
+		}
+	}];
+}
+
+- (void)testObservingDeleteOperation
+{
+	[self insertTestItem];
+	
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Update object expectation"];
+	
+	NSString *originalItemId = self.item.id;
+	
+	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
+		NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
+		NSArray *tableOperations = [self.storeContext executeFetchRequest:tableOperationsRequest error:nil];
+		
+		XCTAssertEqual(tableOperations.count, 1, @"Should have one insert operation after the save of TodoItem %@", self.item);
+		
+		NSManagedObject *tableOperation = tableOperations.firstObject;
+		NSString *operationTable = [tableOperation valueForKey:@"table"];
+		XCTAssertEqualObjects(operationTable, self.item.entity.name, @"The operation should be associated for the %@ table", self.item.entity.name);
+		
+		NSString *operationItemId = [tableOperation valueForKey:@"itemId"];
+		XCTAssertEqualObjects(operationItemId, originalItemId, @"The operation should be associated for the inserted item with id %@", originalItemId);
+		
+		NSDictionary *properties = [[MSJSONSerializer JSONSerializer] itemFromData:[tableOperation valueForKey:@"properties"] withOriginalItem:nil ensureDictionary:YES orError:nil];
+		
+		XCTAssertEqual([properties[@"type"] integerValue], MSTableOperationDelete, @"Associated operation should be an insert with newly created object");
+		
+		XCTAssertNotNil(properties[@"item"], @"Properties should contain the deleted item");
+		
+		[expectation fulfill];
+	}];
+	
+	[self.context deleteObject:self.item];
+	[self.context save:nil];
+	
+	[self waitForExpectationsWithTimeout:3 handler:^(NSError *error) {
+		if (error != nil)
+		{
+			XCTFail(@"Failed to perform delete in 3 seconds");
+		}
+	}];
+}
+
+- (void)testObservingInsertResultingInError
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Table operation observed"];
+	
+	__block int saveCount = 0;
+	
+	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
+		
+		saveCount++;
+		
+		// We only want to test the second save which should cause the error
+		if (saveCount > 1)
+		{
+			XCTAssertNotNil(error, @"Should have an error on second item insert causing duplicate id");
+			
+			[expectation fulfill];
+		}
+	}];
+	
+	[self insertTestItem];
+	
+	// Second insert with duplicate id should cause error
+	[self insertTestItem];
+	
+	[self waitForExpectationsWithTimeout:3 handler:^(NSError *error) {
+		if (error != nil)
+		{
+			XCTFail(@"Expectation for observer save failed");
+		}
+	}];
+}
+
+- (void)testNoInsertWhenMsVersionAttributeDoesntExist
+{
+	[self startObservingContextWithObservationCompletion:^(MSTableOperationTypes operationType, NSDictionary *item, NSError *error) {
+		XCTFail(@"Should not observe any changes for insert in this entity");
+	}];
+	
+	NSManagedObjectContext *todoNoVersion = (NSManagedObjectContext *)[NSEntityDescription
+                                                                       insertNewObjectForEntityForName:@"TodoNoVersion"
+                                                                       inManagedObjectContext:self.context];
+	[todoNoVersion setValue:@"ABC" forKey:@"id"];
+	[todoNoVersion setValue:@"Test text" forKey:@"text"];
+	
+	[self.context save:nil];
+	
+	// As no insert observations will be observed, lets sleep for a bit and ensure no
+	// operations have been inserted
+	sleep(2);
+	
+	NSFetchRequest *tableOperationsRequest = [NSFetchRequest fetchRequestWithEntityName:@"MS_TableOperations"];
+	NSArray *tableOperations = [self.context executeFetchRequest:tableOperationsRequest error:nil];
+	
+	XCTAssertEqual(tableOperations.count, 0, @"Should have no operations pending");
+}
+
+@end

--- a/sdk/test/MSSyncTableTests.m
+++ b/sdk/test/MSSyncTableTests.m
@@ -44,9 +44,6 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 {
     NSLog(@"%@ setUp", self.name);
     
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    config.timeoutIntervalForRequest = 11;
-    
     client = [MSClient clientWithApplicationURLString:@"https://someUrl/"];
     offline = [[MSOfflinePassthroughHelper alloc] initWithManagedObjectContext:[MSCoreDataStore inMemoryManagedObjectContext]];
     
@@ -1139,7 +1136,7 @@ static NSString *const SyncContextQueueName = @"Sync Context: Operation Callback
 -(void) testPushNetworkTimeout
 {
     MSTestFilter *filter = [[MSTestFilter alloc] init];
-    filter.ignoreNextFilter = NO;
+    filter.ignoreNextFilter = YES;
     filter.errorToUse = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:nil];
     
     MSClient *filteredClient = [client clientWithFilter:filter];

--- a/sdk/test/MSUserAgentBuilderTests.m
+++ b/sdk/test/MSUserAgentBuilderTests.m
@@ -34,7 +34,7 @@
     NSString *userAgent = [MSUserAgentBuilder userAgent];
     
 #if TARGET_OS_IPHONE
-    XCTAssertTrue([userAgent isEqualToString:@"ZUMO/3.0 (lang=objective-c; os=--; os_version=--; arch=iOSSimulator; version=3.0.0)"],
+    XCTAssertTrue([userAgent isEqualToString:@"ZUMO/3.1 (lang=objective-c; os=--; os_version=--; arch=iOSSimulator; version=3.1.0)"],
                  @"user agent was: %@", userAgent);
 #endif
 }


### PR DESCRIPTION
This brings the multiple-context branch from services back over to the new apps repo.  In introduces a MSManagedObjectObserver class that will allow working directly with core data and still get tracking operations to use the sync logic later on.