### PR TITLE
Reuse NSURLSession instance

### DIFF
--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -243,6 +243,12 @@
 		F36D9F051C3A46CD002AC412 /* MSConnectionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = F36D9EFF1C3A46CD002AC412 /* MSConnectionConfiguration.m */; };
 		F36D9F1A1C3A4BC2002AC412 /* MSConnectionConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F36D9F191C3A4BC2002AC412 /* MSConnectionConfigurationTests.m */; };
 		F36D9F1B1C3A4BC2002AC412 /* MSConnectionConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F36D9F191C3A4BC2002AC412 /* MSConnectionConfigurationTests.m */; };
+		F3A67D4F1D59588300F07A49 /* MSConnectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A67D4D1D59588300F07A49 /* MSConnectionDelegate.h */; };
+		F3A67D501D59588300F07A49 /* MSConnectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A67D4D1D59588300F07A49 /* MSConnectionDelegate.h */; };
+		F3A67D511D59588300F07A49 /* MSConnectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F3A67D4D1D59588300F07A49 /* MSConnectionDelegate.h */; };
+		F3A67D521D59588300F07A49 /* MSConnectionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F3A67D4E1D59588300F07A49 /* MSConnectionDelegate.m */; };
+		F3A67D531D59588300F07A49 /* MSConnectionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F3A67D4E1D59588300F07A49 /* MSConnectionDelegate.m */; };
+		F3A67D541D59588300F07A49 /* MSConnectionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F3A67D4E1D59588300F07A49 /* MSConnectionDelegate.m */; };
 		F3B70FAA1BAC33E50018AE8D /* MSPullSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D3B9351B290D80002A126A /* MSPullSettings.m */; };
 		F3B70FAB1BAC33EE0018AE8D /* MSPushConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A202C3451AA25F730005A8AE /* MSPushConnection.m */; };
 		F3B70FAC1BAC34090018AE8D /* MSPushConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A202C3441AA25F730005A8AE /* MSPushConnection.h */; };
@@ -536,6 +542,8 @@
 		F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSConnectionConfiguration.h; sourceTree = "<group>"; };
 		F36D9EFF1C3A46CD002AC412 /* MSConnectionConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSConnectionConfiguration.m; sourceTree = "<group>"; };
 		F36D9F191C3A4BC2002AC412 /* MSConnectionConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSConnectionConfigurationTests.m; sourceTree = "<group>"; };
+		F3A67D4D1D59588300F07A49 /* MSConnectionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSConnectionDelegate.h; sourceTree = "<group>"; };
+		F3A67D4E1D59588300F07A49 /* MSConnectionDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSConnectionDelegate.m; sourceTree = "<group>"; };
 		F3B70FAD1BAC34B30018AE8D /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		F3C002331AF7F7450028AB81 /* MSBlockDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSBlockDefinitions.h; sourceTree = "<group>"; };
 		F3C0023A1AF7FF490028AB81 /* MicrosoftAzureMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MicrosoftAzureMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -878,6 +886,8 @@
 				E84CA4CE162369BD009B2588 /* MSUserAgentBuilder.m */,
 				F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */,
 				F36D9EFF1C3A46CD002AC412 /* MSConnectionConfiguration.m */,
+				F3A67D4D1D59588300F07A49 /* MSConnectionDelegate.h */,
+				F3A67D4E1D59588300F07A49 /* MSConnectionDelegate.m */,
 			);
 			name = Connection;
 			sourceTree = "<group>";
@@ -979,6 +989,7 @@
 				5A4FAC771B05E40F0027011D /* MicrosoftAzureMobile.h in Headers */,
 				5A4FACC01B05E67A0027011D /* MSUserAgentBuilder.h in Headers */,
 				5A4FACC21B05E6810027011D /* MSNaiveISODateFormatter.h in Headers */,
+				F3A67D501D59588300F07A49 /* MSConnectionDelegate.h in Headers */,
 				5A4FACBA1B05E6650027011D /* MSAPIRequest.h in Headers */,
 				5A4FAC811B05E4A90027011D /* MSSyncContextInternal.h in Headers */,
 				5A4FAC9C1B05E5620027011D /* MSCoreDataStore.h in Headers */,
@@ -1017,6 +1028,7 @@
 				CF762EC61A1D366E0018C292 /* MSDateOffset.h in Headers */,
 				A24701B9196896F500385DA2 /* MSPush.h in Headers */,
 				F3EA41DD1B0E63470014B587 /* MSQueuePullOperationInternal.h in Headers */,
+				F3A67D4F1D59588300F07A49 /* MSConnectionDelegate.h in Headers */,
 				870C0C9C199C246700A134DD /* MSSDKFeatures.h in Headers */,
 				E8E3790F161F769D00C13F00 /* MSError.h in Headers */,
 				A2C14C6A19105D9F00A58609 /* MSSyncContextReadResult.h in Headers */,
@@ -1090,6 +1102,7 @@
 				F3C0029D1AF7FFF80028AB81 /* MSURLBuilder.h in Headers */,
 				F3C0029E1AF7FFF80028AB81 /* MSUserAgentBuilder.h in Headers */,
 				F3C0029F1AF7FFF80028AB81 /* MSNaiveISODateFormatter.h in Headers */,
+				F3A67D511D59588300F07A49 /* MSConnectionDelegate.h in Headers */,
 				F3C002A01AF7FFF80028AB81 /* MSSerializer.h in Headers */,
 				F3EBDFF51BAC305D00D82B10 /* MSPullSettings.h in Headers */,
 				F3C002A11AF7FFF80028AB81 /* MSJSONSerializer.h in Headers */,
@@ -1344,6 +1357,7 @@
 				5A4FAC8C1B05E5110027011D /* MSQuery.m in Sources */,
 				5A4FAC991B05E5540027011D /* MSPushRequest.m in Sources */,
 				5A4FAC9F1B05E5710027011D /* MSSyncContextReadResult.m in Sources */,
+				F3A67D531D59588300F07A49 /* MSConnectionDelegate.m in Sources */,
 				5A4FAC7E1B05E4970027011D /* MSLoginController.m in Sources */,
 				5A4FACA51B05E5F60027011D /* MSOperationQueue.m in Sources */,
 				5A4FACB91B05E6620027011D /* MSTableRequest.m in Sources */,
@@ -1377,6 +1391,7 @@
 				E8F33B2416166822002DD7C6 /* MSClientConnection.m in Sources */,
 				A202C3471AA25F730005A8AE /* MSPushConnection.m in Sources */,
 				870C0C9D199C246700A134DD /* MSSDKFeatures.m in Sources */,
+				F3A67D521D59588300F07A49 /* MSConnectionDelegate.m in Sources */,
 				A3D7153A1C1A09EC00545C0B /* MSManagedObjectObserver.m in Sources */,
 				A281900518BB2FF5001B14E7 /* MSTableOperationError.m in Sources */,
 				E8F33B2516166822002DD7C6 /* MSTableConnection.m in Sources */,
@@ -1454,6 +1469,7 @@
 				F3C0025A1AF7FFD10028AB81 /* MSPush.m in Sources */,
 				F3C0025B1AF7FFD10028AB81 /* MSPushRequest.m in Sources */,
 				F3C0025C1AF7FFD10028AB81 /* MSPushConnection.m in Sources */,
+				F3A67D541D59588300F07A49 /* MSConnectionDelegate.m in Sources */,
 				F3C0025D1AF7FFD10028AB81 /* MSCoreDataStore.m in Sources */,
 				F36D9F051C3A46CD002AC412 /* MSConnectionConfiguration.m in Sources */,
 				F3C0025E1AF7FFD10028AB81 /* MSSyncContextReadResult.m in Sources */,

--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -367,6 +367,12 @@
 		F3EBE0111BAC312500D82B10 /* CoreDataTestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A28224B1192ACFB700EF8743 /* CoreDataTestModel.xcdatamodeld */; };
 		F3EBE0121BAC313300D82B10 /* WindowsAzureMobileServicesFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F33B34161668C4002DD7C6 /* WindowsAzureMobileServicesFunctionalTests.m */; };
 		F3EBE0131BAC32A000D82B10 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E84CA4D216236A6E009B2588 /* UIKit.framework */; };
+		F3F3B2AD1D6FB8020054B7C4 /* NSURLSessionTask+Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = F3366E881D50636900FBAEF9 /* NSURLSessionTask+Completion.m */; };
+		F3F3B2AE1D6FB8040054B7C4 /* NSURLSessionTask+Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = F3366E881D50636900FBAEF9 /* NSURLSessionTask+Completion.m */; };
+		F3F3B2AF1D6FB8080054B7C4 /* NSURLSessionTask+Completion.h in Headers */ = {isa = PBXBuildFile; fileRef = F3366E871D50636900FBAEF9 /* NSURLSessionTask+Completion.h */; };
+		F3F3B2B01D6FB8090054B7C4 /* NSURLSessionTask+Completion.h in Headers */ = {isa = PBXBuildFile; fileRef = F3366E871D50636900FBAEF9 /* NSURLSessionTask+Completion.h */; };
+		F3F3B2B21D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F3F3B2B11D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m */; };
+		F3F3B2B31D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F3F3B2B11D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -551,6 +557,7 @@
 		F3D8EC931C46485100BE61EB /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		F3EA41DC1B0E62F40014B587 /* MSQueuePullOperationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQueuePullOperationInternal.h; sourceTree = "<group>"; };
 		F3EBDFF31BAC301400D82B10 /* MicrosoftAzureMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MicrosoftAzureMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F3F3B2B11D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionTaskCompletionTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -920,6 +927,7 @@
 				E84CA4D5162373E2009B2588 /* MSUserAgentBuilderTests.m */,
 				A3514E3C1BCC62380032B74C /* MSClientConnectionTests.m */,
 				F36D9F191C3A4BC2002AC412 /* MSConnectionConfigurationTests.m */,
+				F3F3B2B11D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m */,
 			);
 			name = Connection;
 			sourceTree = "<group>";
@@ -994,6 +1002,7 @@
 				5A4FAC811B05E4A90027011D /* MSSyncContextInternal.h in Headers */,
 				5A4FAC9C1B05E5620027011D /* MSCoreDataStore.h in Headers */,
 				5A4FAC7D1B05E4940027011D /* MSLoginView.h in Headers */,
+				F3F3B2AF1D6FB8080054B7C4 /* NSURLSessionTask+Completion.h in Headers */,
 				5A4FACAA1B05E6130027011D /* MSQueuePushOperation.h in Headers */,
 				5A4FACB21B05E6460027011D /* MSClientConnection.h in Headers */,
 				5A4FAC871B05E4F40027011D /* MSDateOffset.h in Headers */,
@@ -1109,6 +1118,7 @@
 				F3C002A21AF7FFF80028AB81 /* MSPredicateTranslator.h in Headers */,
 				F3C0027A1AF7FFF60028AB81 /* MSClientInternal.h in Headers */,
 				F3C0027E1AF7FFF60028AB81 /* MSQueryInternal.h in Headers */,
+				F3F3B2B01D6FB8090054B7C4 /* NSURLSessionTask+Completion.h in Headers */,
 				F3C002801AF7FFF60028AB81 /* MSTableInternal.h in Headers */,
 				A3FD2DB21BB1C40900624DA0 /* MSPullSettingsInternal.h in Headers */,
 				F3C0028A1AF7FFF70028AB81 /* MSSyncContextInternal.h in Headers */,
@@ -1348,6 +1358,7 @@
 				5A4FACAB1B05E6160027011D /* MSQueuePushOperation.m in Sources */,
 				5A4FACAF1B05E6280027011D /* MSTableOperation.m in Sources */,
 				5A4FAC7A1B05E4890027011D /* MSLogin.m in Sources */,
+				F3F3B2AD1D6FB8020054B7C4 /* NSURLSessionTask+Completion.m in Sources */,
 				5A4FACBB1B05E6680027011D /* MSAPIRequest.m in Sources */,
 				5A4FAC861B05E4F00027011D /* MSClient.m in Sources */,
 				5A4FACB51B05E6550027011D /* MSTableConnection.m in Sources */,
@@ -1430,6 +1441,7 @@
 				A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */,
 				A232CCA21AC8FDE800E15D3A /* MSTableOperationErrorTests.m in Sources */,
 				E8F33B3D1616694C002DD7C6 /* MSQueryTests.m in Sources */,
+				F3F3B2B21D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m in Sources */,
 				A3D715431C1A0CD100545C0B /* MSManagedObjectObserverTests.m in Sources */,
 				E8F33B3E16166956002DD7C6 /* MSJSONSerializerTests.m in Sources */,
 				A258891F18A1A30500962F9A /* MSOfflinePassthroughHelper.m in Sources */,
@@ -1463,6 +1475,7 @@
 				F3C002541AF7FFD10028AB81 /* MSClient.m in Sources */,
 				F3C002551AF7FFD10028AB81 /* MSDateOffset.m in Sources */,
 				F3C002561AF7FFD10028AB81 /* MSError.m in Sources */,
+				F3F3B2AE1D6FB8040054B7C4 /* NSURLSessionTask+Completion.m in Sources */,
 				F3C002571AF7FFD10028AB81 /* MSQuery.m in Sources */,
 				F3C002581AF7FFD10028AB81 /* MSTable.m in Sources */,
 				F3C002591AF7FFD10028AB81 /* MSUser.m in Sources */,
@@ -1510,6 +1523,7 @@
 				F3EBDFFB1BAC311D00D82B10 /* MSUserAgentBuilderTests.m in Sources */,
 				A3514E3E1BCC64AB0032B74C /* MSClientConnectionTests.m in Sources */,
 				F3EBDFFC1BAC311D00D82B10 /* MSMultiRequestTestFilter.m in Sources */,
+				F3F3B2B31D6FC1690054B7C4 /* NSURLSessionTaskCompletionTests.m in Sources */,
 				A3D715441C1A0CD200545C0B /* MSManagedObjectObserverTests.m in Sources */,
 				F3EBDFFD1BAC311D00D82B10 /* MSTestFilter.m in Sources */,
 				F3EBDFFE1BAC311D00D82B10 /* MSTable+MSTableTestUtilities.m in Sources */,
@@ -1588,6 +1602,7 @@
 				INFOPLIST_FILE = src/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = "Microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MicrosoftAzureMobile;
 				SKIP_INSTALL = YES;
@@ -1623,6 +1638,7 @@
 				INFOPLIST_FILE = src/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = "Microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MicrosoftAzureMobile;
 				SKIP_INSTALL = YES;
@@ -1735,7 +1751,10 @@
 				DSTROOT = /tmp/WindowsAzureMobileServices.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/MicrosoftAzureMobile-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = MicrosoftAzureMobile;
 				PUBLIC_HEADERS_FOLDER_PATH = headers;
 				SKIP_INSTALL = YES;
@@ -1754,7 +1773,10 @@
 				DSTROOT = /tmp/WindowsAzureMobileServices.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/MicrosoftAzureMobile-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+				);
 				PRODUCT_NAME = MicrosoftAzureMobile;
 				PUBLIC_HEADERS_FOLDER_PATH = headers;
 				SKIP_INSTALL = YES;
@@ -1775,6 +1797,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/MicrosoftAzureMobile-Prefix.pch";
 				INFOPLIST_FILE = "test/MicrosoftAzureMobileTests-Info.plist";
+				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = "Microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MicrosoftAzureMobile;
 			};
@@ -1791,6 +1814,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "src/MicrosoftAzureMobile-Prefix.pch";
 				INFOPLIST_FILE = "test/MicrosoftAzureMobileTests-Info.plist";
+				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = "Microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MicrosoftAzureMobile;
 			};

--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -233,6 +233,8 @@
 		F331FBE71BB003C5004E777C /* MSPullSettingsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D0EFD8581B2F785F009CF6DA /* MSPullSettingsInternal.h */; };
 		F331FBE81BB003C5004E777C /* MSQueuePullOperationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F3EA41DC1B0E62F40014B587 /* MSQueuePullOperationInternal.h */; };
 		F331FBE91BB003C5004E777C /* MSBlockDefinitions.h in Headers */ = {isa = PBXBuildFile; fileRef = F3C002331AF7F7450028AB81 /* MSBlockDefinitions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F3366E891D50636900FBAEF9 /* NSURLSessionTask+Completion.h in Headers */ = {isa = PBXBuildFile; fileRef = F3366E871D50636900FBAEF9 /* NSURLSessionTask+Completion.h */; };
+		F3366E8A1D50636900FBAEF9 /* NSURLSessionTask+Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = F3366E881D50636900FBAEF9 /* NSURLSessionTask+Completion.m */; };
 		F36D9F001C3A46CD002AC412 /* MSConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F36D9F011C3A46CD002AC412 /* MSConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F36D9F021C3A46CD002AC412 /* MSConnectionConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -529,6 +531,8 @@
 		E8F33B36161668DA002DD7C6 /* MSJSONSerializerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSJSONSerializerTests.m; sourceTree = "<group>"; };
 		E8F33B38161668E4002DD7C6 /* MSPredicateTranslatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSPredicateTranslatorTests.m; sourceTree = "<group>"; };
 		E8F33B3A161668ED002DD7C6 /* MSQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSQueryTests.m; sourceTree = "<group>"; };
+		F3366E871D50636900FBAEF9 /* NSURLSessionTask+Completion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionTask+Completion.h"; sourceTree = "<group>"; };
+		F3366E881D50636900FBAEF9 /* NSURLSessionTask+Completion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionTask+Completion.m"; sourceTree = "<group>"; };
 		F36D9EFE1C3A46CD002AC412 /* MSConnectionConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSConnectionConfiguration.h; sourceTree = "<group>"; };
 		F36D9EFF1C3A46CD002AC412 /* MSConnectionConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSConnectionConfiguration.m; sourceTree = "<group>"; };
 		F36D9F191C3A4BC2002AC412 /* MSConnectionConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSConnectionConfigurationTests.m; sourceTree = "<group>"; };
@@ -854,6 +858,8 @@
 		E8F33B1A161667E2002DD7C6 /* Connection */ = {
 			isa = PBXGroup;
 			children = (
+				F3366E871D50636900FBAEF9 /* NSURLSessionTask+Completion.h */,
+				F3366E881D50636900FBAEF9 /* NSURLSessionTask+Completion.m */,
 				E8F33B1E16166822002DD7C6 /* MSClientConnection.h */,
 				E8F33B1F16166822002DD7C6 /* MSClientConnection.m */,
 				E8F33B2016166822002DD7C6 /* MSTableConnection.h */,
@@ -992,6 +998,7 @@
 				7929542819B7C793006A3829 /* MSQueryResult.h in Headers */,
 				E8E3790D161F769D00C13F00 /* MicrosoftAzureMobile.h in Headers */,
 				E84CA4E116272C15009B2588 /* MSLoginController.h in Headers */,
+				F3366E891D50636900FBAEF9 /* NSURLSessionTask+Completion.h in Headers */,
 				E8E3790E161F769D00C13F00 /* MSClient.h in Headers */,
 				A3D7153C1C1A09F300545C0B /* MSManagedObjectObserver.h in Headers */,
 				E8E37911161F769D00C13F00 /* MSTable.h in Headers */,
@@ -1355,6 +1362,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3366E8A1D50636900FBAEF9 /* NSURLSessionTask+Completion.m in Sources */,
 				CF762EC91A1D37A40018C292 /* MSDateOffset.m in Sources */,
 				E8F33B15161667CE002DD7C6 /* MSClient.m in Sources */,
 				A258890C18A19D0B00962F9A /* MSOperationQueue.m in Sources */,

--- a/sdk/src/MSClient.m
+++ b/sdk/src/MSClient.m
@@ -13,7 +13,7 @@
 #import "MSSyncContextInternal.h"
 #import "MSSyncTable.h"
 #import "MSPush.h"
-
+#import "MSConnectionDelegate.h"
 
 #pragma mark * MSClient Private Interface
 
@@ -330,6 +330,35 @@
 {
     // Just use a hard coded reference to MSJSONSerializer
     return [MSJSONSerializer JSONSerializer];
+}
+
+- (MSConnectionDelegate *)connectionDelegate
+{
+    if (!_connectionDelegate)
+    {
+        _connectionDelegate = [[MSConnectionDelegate alloc] initWithClient:self];
+    }
+    return _connectionDelegate;
+}
+
+- (NSURLSession *)urlSession
+{
+    if (!_urlSession)
+    {
+        NSOperationQueue *taskQueue = nil;
+        if (self.connectionDelegateQueue) {
+            taskQueue = self.connectionDelegateQueue;
+        } else {
+            taskQueue = [NSOperationQueue mainQueue];
+        }
+        
+        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        _urlSession = [NSURLSession sessionWithConfiguration:configuration
+                                                    delegate:self.connectionDelegate
+                                               delegateQueue:taskQueue];
+    }
+    
+    return _urlSession;
 }
 
 @end

--- a/sdk/src/MSClient.m
+++ b/sdk/src/MSClient.m
@@ -96,6 +96,12 @@
         _applicationURL = url;
         _login = [[MSLogin alloc] initWithClient:self];
         _push = [[MSPush alloc] initWithClient:self];
+        _connectionDelegate = [[MSConnectionDelegate alloc] initWithClient:self];
+        
+        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        _urlSession = [NSURLSession sessionWithConfiguration:configuration
+                                                    delegate:self.connectionDelegate
+                                               delegateQueue:nil];
     }
     return self;
 }
@@ -332,33 +338,14 @@
     return [MSJSONSerializer JSONSerializer];
 }
 
-- (MSConnectionDelegate *)connectionDelegate
+- (void)setConnectionDelegateQueue:(NSOperationQueue *)connectionDelegateQueue
 {
-    if (!_connectionDelegate)
+    if (connectionDelegateQueue != _connectionDelegateQueue)
     {
-        _connectionDelegate = [[MSConnectionDelegate alloc] initWithClient:self];
+        _connectionDelegateQueue = connectionDelegateQueue;
+        // Pass the queue through to the connection delegate so the completion handler gets called on this queue
+        self.connectionDelegate.completionQueue = connectionDelegateQueue;
     }
-    return _connectionDelegate;
-}
-
-- (NSURLSession *)urlSession
-{
-    if (!_urlSession)
-    {
-        NSOperationQueue *taskQueue = nil;
-        if (self.connectionDelegateQueue) {
-            taskQueue = self.connectionDelegateQueue;
-        } else {
-            taskQueue = [NSOperationQueue mainQueue];
-        }
-        
-        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        _urlSession = [NSURLSession sessionWithConfiguration:configuration
-                                                    delegate:self.connectionDelegate
-                                               delegateQueue:taskQueue];
-    }
-    
-    return _urlSession;
 }
 
 @end

--- a/sdk/src/MSClientConnection.m
+++ b/sdk/src/MSClientConnection.m
@@ -7,6 +7,7 @@
 #import "MSFilter.h"
 #import "MSUser.h"
 #import "MSClientInternal.h"
+#import "NSURLSessionTask+Completion.h"
 
 #pragma mark * HTTP Header String Constants
 
@@ -22,49 +23,14 @@ static NSString *const xZumoInstallId = @"X-ZUMO-INSTALLATION-ID";
 
 #pragma mark * MSConnectionDelegate Private Interface
 
-// The |MSConnection| is a private class as a container for individual
-// connections to store response data and completion block. It is used
-// by the |MSClientConnection| to track tasks in the delegate
-@interface MSConnection : NSObject
-
-/**
- Task identifier for this connection
- */
-@property (nonatomic) NSUInteger identifier;
-
-/**
- Data for this connection
- */
-@property (nonatomic, strong) NSMutableData *data;
-
-/**
- Completion block to be executed once task has completed
- */
-@property (nonatomic, copy) MSResponseBlock completion;
-@end
-
-
 // The |MSConnectionDelegate| is a private class that implements the
 // |NSURLSessionDataDelegate| and surfaces success and error blocks. It
 // is used only by the |MSClientConnection|.
 @interface MSConnectionDelegate : NSObject <NSURLSessionDataDelegate>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 @property (nonatomic, strong) MSClient *client;
-
-/**
- A bag of current connections being executed by the session
- */
-@property (nonatomic, strong) NSMutableDictionary<NSNumber *, MSConnection *> *connections;
-
-
-/**
- Add a task to monitor delegate events
-
- @param task       The session task that should be monitored
- @param completion The block to be called on completion of the task
- */
-- (void)addTask:(NSURLSessionTask *)task completion:(MSResponseBlock)completion;
-
 
 /**
  Singleton connection delegate to manage multiple data tasks with
@@ -88,12 +54,13 @@ static NSOperationQueue *delegateQueue;
 @synthesize request = request_;
 @synthesize completion = completion_;
 
-+(NSURLSession *)sessionWithDelegate:(id<NSURLSessionDelegate>)delegate delegateQueue:(NSOperationQueue *)queue
++(NSURLSession *)sessionWithClient:(MSClient *)client delegateQueue:(NSOperationQueue *)queue
 {
     static NSURLSession *session = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        MSConnectionDelegate *delegate = [MSConnectionDelegate sharedDelegateWithClient:client];
         
         session = [NSURLSession sessionWithConfiguration:configuration
                                                 delegate:delegate
@@ -220,11 +187,10 @@ static NSOperationQueue *delegateQueue;
 			taskQueue = [NSOperationQueue mainQueue];
 		}
 		
-        MSConnectionDelegate *sharedDelegate = [MSConnectionDelegate sharedDelegateWithClient:client];
-		NSURLSession *session = [self sessionWithDelegate:sharedDelegate delegateQueue:taskQueue];
+        NSURLSession *session = [self sessionWithClient:client delegateQueue:taskQueue];
 		NSURLSessionDataTask *task = [session dataTaskWithRequest:request];
+        task.completion = completion;
         
-        [sharedDelegate addTask:task completion:completion];
 		[task resume];
     }
     else {
@@ -310,55 +276,19 @@ static NSOperationQueue *delegateQueue;
 
 #pragma mark * MSConnectionDelegate Private Implementation
 
-@implementation MSConnection
-
-- (instancetype)initWithIdentifier:(NSUInteger)identifier completion:(MSResponseBlock)completion
-{
-    if (self = [super init]) {
-        self.identifier = identifier;
-        self.completion = completion;
-        self.data = [NSMutableData data];
-    }
-    
-    return self;
-}
-
-@end
-
-
 @implementation MSConnectionDelegate
 
 # pragma mark * Public Initializer Methods
 
 + (instancetype)sharedDelegateWithClient:(MSClient *)client
 {
-    static id sharedInstance = nil;
+    static MSConnectionDelegate *sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[[self class] alloc] initWithClient:client];
+        sharedInstance = [[[self class] alloc] init];
+        sharedInstance.client = client;
     });
     return sharedInstance;
-}
-
-- (void)addTask:(NSURLSessionTask *)task completion:(MSResponseBlock)completion
-{
-    MSConnection *connection = [[MSConnection alloc] initWithIdentifier:task.taskIdentifier
-                                                             completion:completion];
-    self.connections[@(task.taskIdentifier)] = connection;
-}
-
-- (instancetype)initWithClient:(MSClient *)client
-{
-    if (self = [super init]) {
-        self.client = client;
-        self.connections = [NSMutableDictionary dictionary];
-    }
-    return self;
-}
-
-- (MSConnection *)connectionForTask:(NSURLSessionTask *)task
-{
-    return self.connections[@(task.taskIdentifier)];
 }
 
 # pragma mark * NSURLSessionDataDelegate Methods
@@ -371,8 +301,7 @@ static NSOperationQueue *delegateQueue;
 
 -(void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
-    MSConnection *connection = [self connectionForTask:dataTask];
-    [connection.data appendData:data];
+    [dataTask.data appendData:data];
 }
 
 -(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler
@@ -393,18 +322,19 @@ static NSOperationQueue *delegateQueue;
 
 -(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    MSConnection *connection = [self connectionForTask:task];
-	if (connection.completion) {
+    MSResponseBlock completion = task.completion;
+	if (completion) {
         // Convert data so we pass an immutable version to the completion handler
-        NSData *data = [NSData dataWithData:connection.data];
-		connection.completion((NSHTTPURLResponse *)task.response, data, error);
+        NSData *data = [NSData dataWithData:task.data];
+		completion((NSHTTPURLResponse *)task.response, data, error);
         [self cleanup:task];
 	}
 }
 
 -(void) cleanup:(NSURLSessionTask *)task
 {
-    [self.connections removeObjectForKey:@(task.taskIdentifier)];
+    task.completion = nil;
+    task.data = nil;
 }
 
 @end

--- a/sdk/src/MSClientInternal.h
+++ b/sdk/src/MSClientInternal.h
@@ -5,6 +5,10 @@
 #import "MSClient.h"
 #import "MSSerializer.h"
 
+@class MSConnectionDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MSClient ()
 
 // The serailizer to use with the client
@@ -14,4 +18,16 @@
 
 - (NSURL *) loginURL;
 
+/**
+ Connection delegate to manage data tasks with the urlSession
+ */
+@property (nonatomic, strong) MSConnectionDelegate *connectionDelegate;
+
+/**
+ Session instance to be used for all data tasks for this client instance
+ */
+@property (nonatomic, strong) NSURLSession *urlSession;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/src/MSConnectionDelegate.h
+++ b/sdk/src/MSConnectionDelegate.h
@@ -1,0 +1,32 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MSClient;
+
+// The |MSConnectionDelegate| is a private class that implements the
+// |NSURLSessionDataDelegate| and surfaces success and error blocks. It
+// is used only by the |MSClientConnection|.
+@interface MSConnectionDelegate : NSObject <NSURLSessionDataDelegate>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Initialize the connection delegate for the client
+
+ @param client The client instance for this delegate to be associated with
+ */
+- (instancetype)initWithClient:(MSClient *)client NS_DESIGNATED_INITIALIZER;
+
+/**
+ The client instance associated with the delegate
+ */
+@property (nonatomic, strong) MSClient *client;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sdk/src/MSConnectionDelegate.h
+++ b/sdk/src/MSConnectionDelegate.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) MSClient *client;
 
+@property (nonatomic, strong, nullable) NSOperationQueue *completionQueue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/src/MSConnectionDelegate.m
+++ b/sdk/src/MSConnectionDelegate.m
@@ -52,9 +52,14 @@
     MSResponseBlock completion = task.completion;
     if (completion)
     {
+        // Default to main queue if no explicit queue has been set
+        NSOperationQueue *callQueue = self.completionQueue ?: [NSOperationQueue mainQueue];
+        
         // Convert data so we pass an immutable version to the completion handler
         NSData *data = [NSData dataWithData:task.data];
-        completion((NSHTTPURLResponse *)task.response, data, error);
+        [callQueue addOperationWithBlock:^{
+            completion((NSHTTPURLResponse *)task.response, data, error);
+        }];
         [self cleanup:task];
     }
 }

--- a/sdk/src/MSConnectionDelegate.m
+++ b/sdk/src/MSConnectionDelegate.m
@@ -1,0 +1,68 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import "MSConnectionDelegate.h"
+#import "MSClient.h"
+#import "NSURLSessionTask+Completion.h"
+
+@implementation MSConnectionDelegate
+
+# pragma mark * Public Initializer Methods
+
+- (instancetype)initWithClient:(MSClient *)client
+{
+    if (self = [super init]) {
+        self.client = client;
+    }
+    return self;
+}
+
+# pragma mark * NSURLSessionDataDelegate Methods
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask willCacheResponse:(NSCachedURLResponse *)proposedResponse completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler
+{
+    // We don't want to cache anything
+    completionHandler(nil);
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+    [dataTask.data appendData:data];
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+    NSURLRequest *newRequest = nil;
+    
+    // Only follow redirects to the Microsoft Azure Mobile Service and not
+    // to other hosts
+    NSString *requestHost = request.URL.host;
+    NSString *applicationHost = self.client.applicationURL.host;
+    if ([applicationHost isEqualToString:requestHost])
+    {
+        newRequest = request;
+    }
+    
+    completionHandler(newRequest);
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    MSResponseBlock completion = task.completion;
+    if (completion)
+    {
+        // Convert data so we pass an immutable version to the completion handler
+        NSData *data = [NSData dataWithData:task.data];
+        completion((NSHTTPURLResponse *)task.response, data, error);
+        [self cleanup:task];
+    }
+}
+
+- (void)cleanup:(NSURLSessionTask *)task
+{
+    task.completion = nil;
+    task.data = nil;
+}
+
+@end

--- a/sdk/src/NSURLSessionTask+Completion.h
+++ b/sdk/src/NSURLSessionTask+Completion.h
@@ -1,10 +1,6 @@
-//
-//  NSURLSessionTask+Completion.h
-//  MicrosoftAzureMobile
-//
-//  Created by Damien Pontifex on 2/08/2016.
-//  Copyright © 2016 Windows Azure. All rights reserved.
-//
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
 #import "MSBlockDefinitions.h"

--- a/sdk/src/NSURLSessionTask+Completion.h
+++ b/sdk/src/NSURLSessionTask+Completion.h
@@ -1,0 +1,23 @@
+//
+//  NSURLSessionTask+Completion.h
+//  MicrosoftAzureMobile
+//
+//  Created by Damien Pontifex on 2/08/2016.
+//  Copyright © 2016 Windows Azure. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "MSBlockDefinitions.h"
+
+@interface NSURLSessionTask(Completion)
+
+/**
+ Completion block to be executed on task being completed
+ */
+@property (nonatomic) MSResponseBlock completion;
+
+/**
+ Data instance used for appending when receiving new data through task
+ */
+@property (nonatomic) NSMutableData *data;
+@end

--- a/sdk/src/NSURLSessionTask+Completion.m
+++ b/sdk/src/NSURLSessionTask+Completion.m
@@ -1,0 +1,42 @@
+//
+//  NSURLSessionTask+Completion.m
+//  MicrosoftAzureMobile
+//
+//  Created by Damien Pontifex on 2/08/2016.
+//  Copyright © 2016 Windows Azure. All rights reserved.
+//
+
+#import <objc/runtime.h>
+#import "NSURLSessionTask+Completion.h"
+
+@implementation NSURLSessionTask(Completion)
+@dynamic completion;
+@dynamic data;
+
+- (MSResponseBlock)completion
+{
+    return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setCompletion:(MSResponseBlock)completion
+{
+    objc_setAssociatedObject(self, _cmd, completion, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSMutableData *)data
+{
+    NSMutableData *_data = objc_getAssociatedObject(self, _cmd);
+    if (!_data) {
+        _data = [NSMutableData data];
+        self.data = _data;
+    }
+    
+    return _data;
+}
+
+- (void)setData:(NSMutableData *)data
+{
+    objc_setAssociatedObject(self, _cmd, data, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+@end

--- a/sdk/src/NSURLSessionTask+Completion.m
+++ b/sdk/src/NSURLSessionTask+Completion.m
@@ -11,17 +11,17 @@
 
 - (MSResponseBlock)completion
 {
-    return objc_getAssociatedObject(self, _cmd);
+    return objc_getAssociatedObject(self, @selector(completion));
 }
 
 - (void)setCompletion:(MSResponseBlock)completion
 {
-    objc_setAssociatedObject(self, _cmd, completion, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(completion), completion, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 - (NSMutableData *)data
 {
-    NSMutableData *_data = objc_getAssociatedObject(self, _cmd);
+    NSMutableData *_data = objc_getAssociatedObject(self, @selector(data));
     if (!_data) {
         _data = [NSMutableData data];
         // Call the explicit setter so the setAssociatedObject method gets called to retain the data
@@ -33,7 +33,7 @@
 
 - (void)setData:(NSMutableData *)data
 {
-    objc_setAssociatedObject(self, _cmd, data, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, @selector(data), data, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end

--- a/sdk/src/NSURLSessionTask+Completion.m
+++ b/sdk/src/NSURLSessionTask+Completion.m
@@ -1,10 +1,6 @@
-//
-//  NSURLSessionTask+Completion.m
-//  MicrosoftAzureMobile
-//
-//  Created by Damien Pontifex on 2/08/2016.
-//  Copyright © 2016 Windows Azure. All rights reserved.
-//
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
 
 #import <objc/runtime.h>
 #import "NSURLSessionTask+Completion.h"

--- a/sdk/src/NSURLSessionTask+Completion.m
+++ b/sdk/src/NSURLSessionTask+Completion.m
@@ -24,6 +24,7 @@
     NSMutableData *_data = objc_getAssociatedObject(self, _cmd);
     if (!_data) {
         _data = [NSMutableData data];
+        // Call the explicit setter so the setAssociatedObject method gets called to retain the data
         self.data = _data;
     }
     
@@ -32,7 +33,7 @@
 
 - (void)setData:(NSMutableData *)data
 {
-    objc_setAssociatedObject(self, _cmd, data, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(self, _cmd, data, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end

--- a/sdk/test/NSURLSessionTaskCompletionTests.m
+++ b/sdk/test/NSURLSessionTaskCompletionTests.m
@@ -1,0 +1,59 @@
+//
+//  NSURLSessionTaskCompletionTests.m
+//  MicrosoftAzureMobile
+//
+//  Created by Damien Pontifex on 26/08/2016.
+//  Copyright © 2016 Windows Azure. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSURLSessionTask+Completion.h"
+
+@interface NSURLSessionTaskCompletionTests : XCTestCase
+@property (strong, nonatomic) NSURLSessionTask *task;
+@end
+
+@implementation NSURLSessionTaskCompletionTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.task = [[NSURLSessionTask alloc] init];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testAlwaysReturnsDataInstance {
+    XCTAssertNotNil(self.task.data);
+    // Initial construction should have empty data
+    XCTAssertEqual(0, self.task.data.length);
+}
+
+- (void)testReturningData {
+    NSString *testString = @"Hello world";
+    NSMutableData *stringData = [[testString dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+    
+    self.task.data = stringData;
+    
+    NSString *retrievedString = [[NSString alloc] initWithData:self.task.data encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([testString isEqualToString:retrievedString]);
+}
+
+- (void)testSettingCompletionBlock {
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Should call completion"];
+    
+    self.task.completion = ^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [expectation fulfill];
+    };
+    
+    self.task.completion(nil, nil, nil);
+    
+    // If our block was retrieved expectation should be fulfilled
+    [self waitForExpectationsWithTimeout:0.1 handler:nil];
+}
+
+@end


### PR DESCRIPTION
It seems the delegate is to the session so implemented a container for connections on the `MSConnectionDelegate` to track multiple tasks executing on the same session and providing the completion callbacks.

No changes to exposed headers so should not cause any breaking changes but may resolve #84 and assist with #83 after required changes to the `pullWithQueryInternal` 