### PR TITLE
Support Refresh Token API

### DIFF
--- a/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
+++ b/sdk/MicrosoftAzureMobile.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		7929542919B7C793006A3829 /* MSQueryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7929542719B7C793006A3829 /* MSQueryResult.m */; };
 		870C0C9C199C246700A134DD /* MSSDKFeatures.h in Headers */ = {isa = PBXBuildFile; fileRef = 870C0C9A199C246700A134DD /* MSSDKFeatures.h */; };
 		870C0C9D199C246700A134DD /* MSSDKFeatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C0C9B199C246700A134DD /* MSSDKFeatures.m */; };
+		9CCEB9011D62733500D70EE4 /* MSLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CCEB9001D62733500D70EE4 /* MSLoginTests.m */; };
 		A202C3461AA25F730005A8AE /* MSPushConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A202C3441AA25F730005A8AE /* MSPushConnection.h */; };
 		A202C3471AA25F730005A8AE /* MSPushConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = A202C3451AA25F730005A8AE /* MSPushConnection.m */; };
 		A214410C182631A500C2E762 /* MSTableFuncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A214410B182631A500C2E762 /* MSTableFuncTests.m */; };
@@ -407,6 +408,7 @@
 		870C0C9B199C246700A134DD /* MSSDKFeatures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSDKFeatures.m; sourceTree = "<group>"; };
 		8790D2BE199C5D510000DC4E /* MSTableInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSTableInternal.h; sourceTree = "<group>"; };
 		8790D2BF199EA5950000DC4E /* MSQueryInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSQueryInternal.h; sourceTree = "<group>"; };
+		9CCEB9001D62733500D70EE4 /* MSLoginTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSLoginTests.m; sourceTree = "<group>"; };
 		A202C3441AA25F730005A8AE /* MSPushConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSPushConnection.h; sourceTree = "<group>"; };
 		A202C3451AA25F730005A8AE /* MSPushConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSPushConnection.m; sourceTree = "<group>"; };
 		A214410B182631A500C2E762 /* MSTableFuncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTableFuncTests.m; sourceTree = "<group>"; };
@@ -825,6 +827,7 @@
 				A2E7D5EF18237F21007153E4 /* Functional */,
 				E87BB01B161A28FC008053F9 /* MSClientTests.m */,
 				E8E37906161F4D0D00C13F00 /* MSFilterTest.m */,
+				9CCEB9001D62733500D70EE4 /* MSLoginTests.m */,
 				E8F33B3A161668ED002DD7C6 /* MSQueryTests.m */,
 				E87BB024161B5A4D008053F9 /* MSTableTests.m */,
 				CF4D498D1A3253F7006AEB70 /* MSTestWaiter.h */,
@@ -1413,6 +1416,7 @@
 				E8F33B3F1616695E002DD7C6 /* MSPredicateTranslatorTests.m in Sources */,
 				A2ADF7E91914481B0078BB16 /* MSTableOperationTests.m in Sources */,
 				A258891E18A1A30000962F9A /* MSSyncTableTests.m in Sources */,
+				9CCEB9011D62733500D70EE4 /* MSLoginTests.m in Sources */,
 				E87BB01C161A28FC008053F9 /* MSClientTests.m in Sources */,
 				E87BB022161B57C8008053F9 /* MSUserTests.m in Sources */,
 				E87BB025161B5A4D008053F9 /* MSTableTests.m in Sources */,

--- a/sdk/src/MSClient.h
+++ b/sdk/src/MSClient.h
@@ -138,6 +138,9 @@
 /// Logs out the current end user.
 -(void)logoutWithCompletion:(nullable MSClientLogoutBlock)completion;
 
+/// Refreshes access token with the identity provider for the logged in user.
+-(void)refreshUserWithCompletion:(nullable MSClientLoginBlock)completion;
+
 /// @}
 
 #pragma mark * Public Table Methods

--- a/sdk/src/MSClient.m
+++ b/sdk/src/MSClient.m
@@ -237,6 +237,10 @@
     }
 }
 
+-(void)refreshUserWithCompletion:(nullable MSClientLoginBlock)completion
+{
+    return [self.login refreshUserWithCompletion:completion];
+}
 
 #pragma mark * Public Table Constructor Methods
 

--- a/sdk/src/MSClientConnection.h
+++ b/sdk/src/MSClientConnection.h
@@ -33,17 +33,17 @@
 #pragma  mark * Public Initializer Methods
 
 
-// Initializes an |MSClientConnection| with the given client sends the given
+// Initializes an |MSClientConnection| with the given client that sends the given
 // request. NOTE: The request is not sent until |start| is called.
 -(id)initWithRequest:(NSURLRequest *)request
               client:(MSClient *)client
           completion:(MSResponseBlock)completion;
 
-// Initializes an |MSClientConnection| with the given client sends the given
-// request with SDK features.
+// Initializes an |MSClientConnection| with the given client that sends the given
+// request using certain MSFeatures.
 -(id)initWithRequest:(NSURLRequest *)request
               client:(MSClient *)client
-            features:(MSSDKFeatures *)features
+            features:(MSFeatures)features
           completion:(MSResponseBlock)completion;
 
 

--- a/sdk/src/MSClientConnection.h
+++ b/sdk/src/MSClientConnection.h
@@ -4,6 +4,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSBlockDefinitions.h"
+#import "MSSDKFeatures.h"
 
 @class MSClient;
 
@@ -36,6 +37,13 @@
 // request. NOTE: The request is not sent until |start| is called.
 -(id)initWithRequest:(NSURLRequest *)request
               client:(MSClient *)client
+          completion:(MSResponseBlock)completion;
+
+// Initializes an |MSClientConnection| with the given client sends the given
+// request with SDK features.
+-(id)initWithRequest:(NSURLRequest *)request
+              client:(MSClient *)client
+            features:(MSSDKFeatures *)features
           completion:(MSResponseBlock)completion;
 
 

--- a/sdk/src/MSClientConnection.m
+++ b/sdk/src/MSClientConnection.m
@@ -270,9 +270,7 @@ static NSOperationQueue *delegateQueue;
         }
     }
     
-    if (features) {
-        [mutableRequest setValue:[MSSDKFeatures httpHeaderForFeatures:features] forHTTPHeaderField:MSFeaturesHeaderName];
-    }
+    [mutableRequest setValue:[MSSDKFeatures httpHeaderForFeatures:features] forHTTPHeaderField:MSFeaturesHeaderName];
     
     return mutableRequest;
 }

--- a/sdk/src/MSClientConnection.m
+++ b/sdk/src/MSClientConnection.m
@@ -67,20 +67,12 @@ static NSOperationQueue *delegateQueue;
                client:(MSClient *)client
            completion:(MSResponseBlock)completion
 {
-    self = [super init];
-    if (self) {
-        client_ = client;
-        request_ = [MSClientConnection configureHeadersOnRequest:request
-                                                      withClient:client];
-        completion_ = [completion copy];
-    }
-    
-    return self;
+    return [self initWithRequest:request client:client features:MSFeatureNone completion:completion];
 }
 
 -(id) initWithRequest:(NSURLRequest *)request
                client:(MSClient *)client
-             features:(MSSDKFeatures *)features
+             features:(MSFeatures)features
            completion:(MSResponseBlock)completion
 {
     self = [super init];
@@ -229,18 +221,7 @@ static NSOperationQueue *delegateQueue;
 
 +(NSURLRequest *) configureHeadersOnRequest:(NSURLRequest *)request
                                  withClient:(MSClient *)client
-                                withFeatures:(MSSDKFeatures *)features
-{
-    NSMutableURLRequest *mutableRequest = [MSClientConnection configureHeadersOnRequest:request withClient:client];
-
-    [mutableRequest setValue:[MSSDKFeatures httpHeaderForFeatures:features]
-                    forHTTPHeaderField:MSFeaturesHeaderName];
-    
-    return mutableRequest;
-}
-
-+(NSURLRequest *) configureHeadersOnRequest:(NSURLRequest *)request
-                                 withClient:(MSClient *)client
+                                withFeatures:(MSFeatures)features
 {
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
     
@@ -287,6 +268,10 @@ static NSOperationQueue *delegateQueue;
             [mutableRequest setValue:jsonContentType
                   forHTTPHeaderField:contentTypeHeader];
         }
+    }
+    
+    if (features) {
+        [mutableRequest setValue:[MSSDKFeatures httpHeaderForFeatures:features] forHTTPHeaderField:MSFeaturesHeaderName];
     }
     
     return mutableRequest;

--- a/sdk/src/MSClientConnection.m
+++ b/sdk/src/MSClientConnection.m
@@ -7,6 +7,7 @@
 #import "MSFilter.h"
 #import "MSUser.h"
 #import "MSClientInternal.h"
+#import "MSSDKFeatures.h"
 
 #pragma mark * HTTP Header String Constants
 
@@ -77,6 +78,22 @@ static NSOperationQueue *delegateQueue;
     return self;
 }
 
+-(id) initWithRequest:(NSURLRequest *)request
+               client:(MSClient *)client
+             features:(MSSDKFeatures *)features
+           completion:(MSResponseBlock)completion
+{
+    self = [super init];
+    if (self) {
+        client_ = client;
+        request_ = [MSClientConnection configureHeadersOnRequest:request
+                                                      withClient:client
+                                                    withFeatures:features];
+        completion_ = [completion copy];
+    }
+    
+    return self;
+}
 
 #pragma mark * Public Start Methods
 
@@ -208,6 +225,18 @@ static NSOperationQueue *delegateQueue;
                            next:onNext
                        response:completion];
     }
+}
+
++(NSURLRequest *) configureHeadersOnRequest:(NSURLRequest *)request
+                                 withClient:(MSClient *)client
+                                withFeatures:(MSSDKFeatures *)features
+{
+    NSMutableURLRequest *mutableRequest = [MSClientConnection configureHeadersOnRequest:request withClient:client];
+
+    [mutableRequest setValue:[MSSDKFeatures httpHeaderForFeatures:features]
+                    forHTTPHeaderField:MSFeaturesHeaderName];
+    
+    return mutableRequest;
 }
 
 +(NSURLRequest *) configureHeadersOnRequest:(NSURLRequest *)request

--- a/sdk/src/MSError.h
+++ b/sdk/src/MSError.h
@@ -203,6 +203,9 @@ extern NSString *const MSErrorPushResultKey;
 /// or expired
 #define MSRefreshForbidden                      -1509
 
+/// Indicates that the refresh user operation failed due to an unexpected error
+#define MSRefreshUnexpectedError                -1510
+
 /// Indicates that a required parameter for push operation was not provided
 #define MSPushRequiredParameter                 -1600
 

--- a/sdk/src/MSError.h
+++ b/sdk/src/MSError.h
@@ -194,17 +194,17 @@ extern NSString *const MSErrorPushResultKey;
 
 /// Indicates that the refresh user operation failed because the identity provider
 /// does not support refresh token or user is not logged in with sufficient permission
-#define MSRefreshBadRequest                     -1507
+#define MSRefreshBadRequest                     -1511
 
 /// Indicates that the refresh user operation failed because credentials are not valid
-#define MSRefreshUnauthorized                   -1508
+#define MSRefreshUnauthorized                   -1512
 
 /// Indicates that the refresh user operation failed because refresh token was revoked
 /// or expired
-#define MSRefreshForbidden                      -1509
+#define MSRefreshForbidden                      -1513
 
 /// Indicates that the refresh user operation failed due to an unexpected error
-#define MSRefreshUnexpectedError                -1510
+#define MSRefreshUnexpectedError                -1514
 
 /// Indicates that a required parameter for push operation was not provided
 #define MSPushRequiredParameter                 -1600

--- a/sdk/src/MSError.h
+++ b/sdk/src/MSError.h
@@ -192,6 +192,17 @@ extern NSString *const MSErrorPushResultKey;
 /// was invalid.
 #define MSLoginInvalidURL                       -1506
 
+/// Indicates that the refresh user operation failed because the identity provider
+/// does not support refresh token or user is not logged in with sufficient permission
+#define MSRefreshBadRequest                     -1507
+
+/// Indicates that the refresh user operation failed because credentials are not valid
+#define MSRefreshUnauthorized                   -1508
+
+/// Indicates that the refresh user operation failed because refresh token was revoked
+/// or expired
+#define MSRefreshForbidden                      -1509
+
 /// Indicates that a required parameter for push operation was not provided
 #define MSPushRequiredParameter                 -1600
 

--- a/sdk/src/MSLogin.h
+++ b/sdk/src/MSLogin.h
@@ -58,4 +58,7 @@
                    token:(NSDictionary *)token
               completion:(MSClientLoginBlock)completion;
 
+// Refreshes access token with the identity provider for the logged in user.
+-(void)refreshUserWithCompletion:(nullable MSClientLoginBlock)completion;
+
 @end

--- a/sdk/src/MSLogin.m
+++ b/sdk/src/MSLogin.m
@@ -195,7 +195,7 @@
             if (!responseError) {
                 if (response.statusCode == 200) {
                     user = [[MSLoginSerializer loginSerializer] userFromData:data orError:&responseError];
-                    if (user.mobileServiceAuthenticationToken) {
+                    if (!responseError) {
                         self.client.currentUser.mobileServiceAuthenticationToken = user.mobileServiceAuthenticationToken;
                     }
                 }

--- a/sdk/src/MSLoginSerializer.m
+++ b/sdk/src/MSLoginSerializer.m
@@ -99,7 +99,12 @@ static MSLoginSerializer *staticLoginSerializerSingleton;
             }
             else {
                 user = [[MSUser alloc] initWithUserId:userId];
-                user.mobileServiceAuthenticationToken = authToken;
+                if (user) {
+                    user.mobileServiceAuthenticationToken = authToken;
+                }
+                else {
+                    localError = [self errorForInvalidUserJson];
+                }
             }
         }
     }

--- a/sdk/src/MSSDKFeatures.h
+++ b/sdk/src/MSSDKFeatures.h
@@ -39,7 +39,10 @@ typedef NS_OPTIONS(NSUInteger, MSFeatures) {
     MSFeatureReadWithLinkHeader       = 1 << 7,
     
     // Table read is using incremental pull
-    MSFeatureIncrementalPull          = 1 << 8
+    MSFeatureIncrementalPull          = 1 << 8,
+    
+    // Refresh Token
+    MSFeatureRefreshToken             = 1 << 9
 };
 
 extern NSString *const MSFeaturesHeaderName;
@@ -52,6 +55,7 @@ extern NSString *const MSFeatureCodeTableReadRaw;
 extern NSString *const MSFeatureCodeOpportunisticConcurrency;
 extern NSString *const MSFeatureCodeOffline;
 extern NSString *const MSFeatureCodeIncrementalPull;
+extern NSString *const MSFeatureCodeRefreshToken;
 
 
 // The |MSSDKFeatures| class defines methods to convert between the

--- a/sdk/src/MSSDKFeatures.m
+++ b/sdk/src/MSSDKFeatures.m
@@ -16,6 +16,7 @@ NSString *const MSFeatureCodeOpportunisticConcurrency = @"OC";
 NSString *const MSFeatureCodeOffline = @"OL";
 NSString *const MSFeatureCodeReadWithLinkHeader = @"LH";
 NSString *const MSFeatureCodeIncrementalPull = @"IP";
+NSString *const MSFeatureCodeRefreshToken = @"RT";
 
 @implementation MSSDKFeatures
 
@@ -49,6 +50,9 @@ NSString *const MSFeatureCodeIncrementalPull = @"IP";
     }
     if (features & MSFeatureIncrementalPull) {
         [allFeatures addObject:MSFeatureCodeIncrementalPull];
+    }
+    if (features & MSFeatureRefreshToken) {
+        [allFeatures addObject:MSFeatureCodeRefreshToken];
     }
 
     return [allFeatures componentsJoinedByString:@","];

--- a/sdk/test/MSLoginTests.m
+++ b/sdk/test/MSLoginTests.m
@@ -1,0 +1,137 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSClient.h"
+#import "MSJsonSerializer.h"
+#import "MSLogin.h"
+#import "MSTestFilter.h"
+#import "MSUser.h"
+
+@interface MSLoginTests : XCTestCase {
+    BOOL done;
+}
+
+@end
+
+
+@implementation MSLoginTests
+
+#pragma mark * Setup and TearDown
+
+- (void)setUp {
+    NSLog(@"%@ setUp", self.name);
+    
+    done = NO;
+}
+
+- (void)tearDown {
+    NSLog(@"%@ tearDown", self.name);
+}
+
+#pragma mark * Refresh User Tests
+
+- (void)testRefreshUser
+{
+    MSClient *client = [MSClient clientWithApplicationURLString:@"http://someURL.com"];
+
+    MSTestFilter *testFilter = [MSTestFilter testFilterWithStatusCode:200];
+    
+    testFilter.onInspectResponseData = ^(NSURLRequest *request, NSData *data) {
+        NSDictionary *item = @{ @"user" : @{ @"userId" : @"sid:12345678" }, @"authenticationToken" : @"token12345678" };
+        return [[MSJSONSerializer JSONSerializer] dataFromItem:item idAllowed:YES ensureDictionary:NO removeSystemProperties:YES orError:nil];
+    };
+    
+    MSClient *filterClient = [client clientWithFilter:testFilter];
+    
+    // Invoke the API
+    [filterClient refreshUserWithCompletion:
+     ^(MSUser *user, NSError *error) {
+         XCTAssertNil(error);
+         XCTAssertNotNil(user);
+         XCTAssertEqualObjects(user.userId, @"sid:12345678");
+         XCTAssertEqualObjects(user.mobileServiceAuthenticationToken, @"token12345678");
+         done = YES;
+     }];
+    
+    XCTAssertTrue([self waitForTest:1], @"Test timed out.");
+}
+
+- (void)testRefreshUser400Error
+{
+    MSClient *client = [MSClient clientWithApplicationURLString:@"http://someURL.com"];
+    
+    MSTestFilter *testFilter = [MSTestFilter testFilterWithStatusCode:400];
+    
+    MSClient *filterClient = [client clientWithFilter:testFilter];
+    
+    // Invoke the API
+    [filterClient refreshUserWithCompletion:
+     ^(MSUser *user, NSError *error) {
+         XCTAssertNotNil(error);
+         XCTAssertEqual(error.code, MSRefreshBadRequest);
+         done = YES;
+     }];
+    
+    XCTAssertTrue([self waitForTest:1], @"Test timed out.");
+}
+
+- (void)testRefreshUser401Error
+{
+    MSClient *client = [MSClient clientWithApplicationURLString:@"http://someURL.com"];
+    
+    MSTestFilter *testFilter = [MSTestFilter testFilterWithStatusCode:401];
+
+    MSClient *filterClient = [client clientWithFilter:testFilter];
+    
+    // Invoke the API
+    [filterClient refreshUserWithCompletion:
+     ^(MSUser *user, NSError *error) {
+         XCTAssertNotNil(error);
+         XCTAssertEqual(error.code, MSRefreshUnauthorized);
+         done = YES;
+     }];
+    
+    XCTAssertTrue([self waitForTest:1], @"Test timed out.");
+}
+
+- (void)testRefreshUser403Error
+{
+    MSClient *client = [MSClient clientWithApplicationURLString:@"http://someURL.com"];
+    
+    MSTestFilter *testFilter = [MSTestFilter testFilterWithStatusCode:403];
+    
+    MSClient *filterClient = [client clientWithFilter:testFilter];
+    
+    // Invoke the API
+    [filterClient refreshUserWithCompletion:
+     ^(MSUser *user, NSError *error) {
+         XCTAssertNotNil(error);
+         XCTAssertEqual(error.code, MSRefreshForbidden);
+         done = YES;
+     }];
+    
+    XCTAssertTrue([self waitForTest:1], @"Test timed out.");
+}
+
+#pragma mark * Async Test Helper Method
+
+
+-(BOOL) waitForTest:(NSTimeInterval)testDuration {
+    
+    NSDate *timeoutAt = [NSDate dateWithTimeIntervalSinceNow:testDuration];
+    
+    while (!done) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:timeoutAt];
+        if([timeoutAt timeIntervalSinceNow] <= 0.0) {
+            break;
+        }
+    };
+    
+    return done;
+}
+
+
+@end

--- a/sdk/test/settings.plist
+++ b/sdk/test/settings.plist
@@ -4,7 +4,5 @@
 <dict>
 	<key>TestAppUrl</key>
 	<string></string>
-	<key>TestAppApplicationKey</key>
-	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR to address Issue #62, a basic implementation that calls the refresh with "X-ZUMO-AUTH" and sets the mobile service auth token. The Refresh API includes "X-ZUMO-FEATURES" HTTP header for internal telemetry purpose as well.

@shrishrirang @pragnagopa can you review this? Thanks.