### PR TITLE
Add ZumoE2ETest.xcworkspace for local e2e testing

### DIFF
--- a/ZumoE2ETest.xcworkspace/contents.xcworkspacedata
+++ b/ZumoE2ETest.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:e2etest/ZumoE2ETestApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "container:sdk/MicrosoftAzureMobile.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
Adding a ZumoE2ETest.xcworkspace in root directory containing sdk/MicrosoftAzureMobile.xcodeproj and e2etest/ZumoE2ETestApp.xcodeproj. This makes local debugging of MicrosoftAzureMobile code in e2etest easier.
