### PR TITLE
changing to use xcode auto synthesize properties

### DIFF
--- a/sdk/src/MSAPIConnection.m
+++ b/sdk/src/MSAPIConnection.m
@@ -21,8 +21,6 @@
 
 @implementation MSAPIConnection
 
-@synthesize serializer = serializer_;
-
 
 #pragma mark * Public Static Constructors
 

--- a/sdk/src/MSClient.m
+++ b/sdk/src/MSClient.m
@@ -45,24 +45,24 @@
     }
 }
 
-@synthesize installId = installId_;
+@synthesize installId = _installId;
 -(NSString *) installId
 {
-    if(!installId_) {
+    if(!_installId) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        installId_ = [defaults stringForKey:@"WindowsAzureMobileServicesInstallationId"];
-        if(!installId_) {
+        _installId = [defaults stringForKey:@"WindowsAzureMobileServicesInstallationId"];
+        if(!_installId) {
             CFUUIDRef newUUID = CFUUIDCreate(kCFAllocatorDefault);
-            installId_ = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, newUUID);
+            _installId = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, newUUID);
             CFRelease(newUUID);
         
             //store the install ID so we don't generate a new one next time
-            [defaults setObject:installId_ forKey:@"WindowsAzureMobileServicesInstallationId"];
+            [defaults setObject:_installId forKey:@"WindowsAzureMobileServicesInstallationId"];
             [defaults synchronize];
         }
     }
     
-    return installId_;
+    return _installId;
 }
 
 #pragma mark * Public Static Constructor Methods

--- a/sdk/src/MSClientConnection.m
+++ b/sdk/src/MSClientConnection.m
@@ -64,10 +64,6 @@ static NSString *const xZumoInstallId = @"X-ZUMO-INSTALLATION-ID";
 
 static NSOperationQueue *delegateQueue;
 
-@synthesize client = client_;
-@synthesize request = request_;
-@synthesize completion = completion_;
-
 # pragma mark * Public Initializer Methods
 
 -(id) initWithRequest:(NSURLRequest *)request
@@ -84,11 +80,11 @@ static NSOperationQueue *delegateQueue;
 {
     self = [super init];
     if (self) {
-        client_ = client;
-        request_ = [MSClientConnection configureHeadersOnRequest:request
+        _client = client;
+        _request = [MSClientConnection configureHeadersOnRequest:request
                                                       withClient:client
                                                     withFeatures:features];
-        completion_ = [completion copy];
+        _completion = [completion copy];
     }
     
     return self;

--- a/sdk/src/MSLogin.m
+++ b/sdk/src/MSLogin.m
@@ -31,8 +31,6 @@
 
 @implementation MSLogin
 
-@synthesize client = client_;
-
 
 #pragma  mark * Public Initializer Methods
 
@@ -41,7 +39,7 @@
 {
     self = [super init];
     if (self) {
-        client_ = client;
+        _client = client;
     }
     
     return self;

--- a/sdk/src/MSLoginView.m
+++ b/sdk/src/MSLoginView.m
@@ -38,19 +38,6 @@ NSString *const MSLoginViewErrorResponseData = @"com.Microsoft.MicrosoftAzureMob
 
 @implementation MSLoginView
 
-@synthesize client = client_;
-@synthesize startURL = startURL_;
-@synthesize endURL = endURL_;
-@synthesize toolbar = toolbar_;
-@synthesize showToolbar = showToolbar_;
-@synthesize toolbarPosition = toolbarPosition_;
-@synthesize activityIndicator = activityIndicator_;
-@synthesize webView = webView_;
-@synthesize currentURL = currentURL_;
-@synthesize endURLString = endURLString_;
-@synthesize completion = completion_;
-
-
 #pragma mark * Public Initializer and Dealloc Methods
 
 
@@ -64,33 +51,33 @@ NSString *const MSLoginViewErrorResponseData = @"com.Microsoft.MicrosoftAzureMob
     if (self) {
         
         // Capture all of the initializer values as properties
-        client_ = client;
-        startURL_ = startURL;
-        endURL_ = endURL;
-        endURLString_ = endURL_.absoluteString;        
-        completion_ = [completion copy];
+        _client = client;
+        _startURL = startURL;
+        _endURL = endURL;
+        _endURLString = _endURL.absoluteString;        
+        _completion = [completion copy];
         
         // Create the activity indicator and toolbar
-        activityIndicator_ = [[UIActivityIndicatorView alloc]
+        _activityIndicator = [[UIActivityIndicatorView alloc]
                               initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
-        toolbar_ = [self createToolbar:activityIndicator_];
-        [self addSubview:toolbar_];
+        _toolbar = [self createToolbar:_activityIndicator];
+        [self addSubview:_toolbar];
         
         // Set the toolbar defaults
-        showToolbar_ = YES;
-        toolbarPosition_ = UIToolbarPositionBottom;
+        _showToolbar = YES;
+        _toolbarPosition = UIToolbarPositionBottom;
         
         // Create the webview
-        webView_ = [[WKWebView alloc] init];
-        webView_.navigationDelegate = self;
-        [self addSubview:webView_];
+        _webView = [[WKWebView alloc] init];
+        _webView.navigationDelegate = self;
+        [self addSubview:_webView];
         
         // Call setViewFrames to update the subview frames
         [self setViewFrames];
         
         // Start the first request
         NSURLRequest *firstRequest = [NSURLRequest requestWithURL:startURL];
-        [webView_ loadRequest:firstRequest];
+        [_webView loadRequest:firstRequest];
     }
     return self;
 }
@@ -100,8 +87,8 @@ NSString *const MSLoginViewErrorResponseData = @"com.Microsoft.MicrosoftAzureMob
 
 -(void) setShowToolbar:(BOOL)showToolbar
 {
-    if (showToolbar != showToolbar_) {
-        showToolbar_ = showToolbar;
+    if (showToolbar != _showToolbar) {
+        _showToolbar = showToolbar;
         [self setViewFrames];
     }
 }
@@ -112,8 +99,8 @@ NSString *const MSLoginViewErrorResponseData = @"com.Microsoft.MicrosoftAzureMob
 
 -(void) setToolbarPosition:(UIToolbarPosition)toolbarPosition
 {
-    if (toolbarPosition != toolbarPosition_) {
-        toolbarPosition_ = toolbarPosition;
+    if (toolbarPosition != _toolbarPosition) {
+        _toolbarPosition = toolbarPosition;
         [self setViewFrames];
     }
 }

--- a/sdk/src/MSOperationQueue.m
+++ b/sdk/src/MSOperationQueue.m
@@ -17,17 +17,14 @@
 @end
 
 @implementation MSOperationQueue
-@synthesize dataSource = dataSource_;
-@synthesize client = client_;
-@synthesize locks = locks_;
 
 - (id) initWithClient:(MSClient *)client dataSource:(id<MSSyncContextDataSource>)dataSource
 {
     self = [super init];
     if (self) {
-        dataSource_ = dataSource;
-        client_ = client;
-        locks_ = [NSMutableDictionary new];
+        _dataSource = dataSource;
+        _client = client;
+        _locks = [NSMutableDictionary new];
     }
     return self;
 }

--- a/sdk/src/MSQuery.m
+++ b/sdk/src/MSQuery.m
@@ -15,17 +15,6 @@
 
 @implementation MSQuery
 
-@synthesize table = table_;
-@synthesize syncTable = syncTable_;
-@synthesize fetchLimit = fetchLimit_;
-@synthesize fetchOffset = fetchOffset_;
-@synthesize includeTotalCount = includeTotalCount_;
-@synthesize parameters = parameters_;
-@synthesize selectFields = selectFields_;
-@synthesize predicate = predicate_;
-@synthesize orderBy = orderBy_;
-
-
 #pragma mark * Public Initializer Methods
 
 
@@ -55,14 +44,14 @@
     if (self)
     {
         if ([table isKindOfClass:[MSSyncTable class]]) {
-            syncTable_ = table;
+            _syncTable = table;
         } else {
-            table_ = table;
+            _table = table;
         }
         
-        predicate_ = predicate;
-        fetchLimit_ = -1;
-        fetchOffset_ = -1;
+        _predicate = predicate;
+        _fetchLimit = -1;
+        _fetchOffset = -1;
     }
     return self;
 }

--- a/sdk/src/MSQueryResult.m
+++ b/sdk/src/MSQueryResult.m
@@ -5,9 +5,6 @@
 #import "MSQueryResult.h"
 
 @implementation MSQueryResult
-@synthesize totalCount = totalCount_;
-@synthesize items = items_;
-@synthesize nextLink = nextLink_;
 
 -(id)initWithItems:(NSArray<NSDictionary *> *)items
         totalCount:(NSInteger) totalCount
@@ -15,9 +12,9 @@
 {
     self = [super init];
     if (self) {
-        totalCount_ = totalCount;
-        items_ = items;
-        nextLink_ = nextLink;
+        _totalCount = totalCount;
+        _items = items;
+        _nextLink = nextLink;
     }
     
     return self;

--- a/sdk/src/MSSyncContext.m
+++ b/sdk/src/MSSyncContext.m
@@ -26,16 +26,10 @@
 
 static NSOperationQueue *pushQueue_;
 
-@synthesize delegate = delegate_;
-@synthesize dataSource = dataSource_;
-@synthesize operationQueue = operationQueue_;
-@synthesize client = client_;
-@synthesize callbackQueue = callbackQueue_;
-
 -(void) setClient:(MSClient *)client
 {
-    client_ = client;
-    operationQueue_ = [[MSOperationQueue alloc] initWithClient:client_ dataSource:self.dataSource];
+    _client = client;
+    _operationQueue = [[MSOperationQueue alloc] initWithClient:_client dataSource:self.dataSource];
 
     // We don't need to wait for this, and all operation creation goes onto this queue so its
     // guaranteed to happen only after this is populated.
@@ -57,19 +51,19 @@ static NSOperationQueue *pushQueue_;
         _writeOperationQueue = dispatch_queue_create("WriteOperationQueue", DISPATCH_QUEUE_SERIAL);
         _readOperationQueue = dispatch_queue_create("ReadOperationQueue",  DISPATCH_QUEUE_CONCURRENT);
 
-        callbackQueue_ = callbackQueue;
-        if (!callbackQueue_) {
-            callbackQueue_ = [[NSOperationQueue alloc] init];
-            callbackQueue_.name = @"Sync Context: Operation Callbacks";
-            callbackQueue_.maxConcurrentOperationCount = 4;
+        _callbackQueue = callbackQueue;
+        if (!_callbackQueue) {
+            _callbackQueue = [[NSOperationQueue alloc] init];
+            _callbackQueue.name = @"Sync Context: Operation Callbacks";
+            _callbackQueue.maxConcurrentOperationCount = 4;
         }
         
         pushQueue_ = [NSOperationQueue new];
         pushQueue_.maxConcurrentOperationCount = 1;
         pushQueue_.name = @"Sync Context: Push";
         
-        dataSource_ = dataSource;
-        delegate_ = delegate;
+        _dataSource = dataSource;
+        _delegate = delegate;
     }
     
     return self;

--- a/sdk/src/MSSyncContextReadResult.m
+++ b/sdk/src/MSSyncContextReadResult.m
@@ -6,15 +6,12 @@
 
 @implementation MSSyncContextReadResult
 
-@synthesize totalCount = totalCount_;
-@synthesize items = items_;
-
 - (id)initWithCount:(NSInteger)count items:(NSArray<NSDictionary *> *)items;
 {
     self = [super init];
     if (self) {
-        totalCount_ = count;
-        items_ = items;
+        _totalCount = count;
+        _items = items;
     }
     
     return self;

--- a/sdk/src/MSTable.m
+++ b/sdk/src/MSTable.m
@@ -21,10 +21,6 @@ NSString *const MSSystemColumnDeleted = @"deleted";
 
 @implementation MSTable
 
-@synthesize client = client_;
-@synthesize name = name_;
-@synthesize features = features_;
-
 #pragma mark * Public Initializer Methods
 
 
@@ -33,9 +29,9 @@ NSString *const MSSystemColumnDeleted = @"deleted";
     self = [super init];
     if (self)
     {
-        client_ = client;
-        name_ = tableName;
-        features_ = MSFeatureNone;
+        _client = client;
+        _name = tableName;
+        _features = MSFeatureNone;
     }
     return self;
 }

--- a/sdk/src/MSTableConnection.m
+++ b/sdk/src/MSTableConnection.m
@@ -17,8 +17,6 @@ static NSString *const nextLinkPattern = @"^(.*?);\\s*rel\\s*=\\s*(\\w+)\\s*"; /
 
 @implementation MSTableConnection
 
-@synthesize table = table_;
-
 
 #pragma mark * Public Static Constructors
 
@@ -228,7 +226,7 @@ static NSString *const nextLinkPattern = @"^(.*?);\\s*rel\\s*=\\s*(\\w+)\\s*"; /
                         completion:completion];
     
     if (self) {
-        table_ = request.table;
+        _table = request.table;
     }
     
     return self;

--- a/sdk/src/MSTableOperation.m
+++ b/sdk/src/MSTableOperation.m
@@ -11,12 +11,6 @@
 
 @implementation MSTableOperation
 
-@synthesize operationId = operationId_;
-@synthesize type = type_;
-@synthesize tableName = tableName_;
-@synthesize itemId = itemId_;
-@synthesize item = item_;
-
 +(MSTableOperation *) pushOperationForTable:(NSString *)tableName
                                       type:(MSTableOperationTypes)type
                                       itemId:(NSString *)itemId;
@@ -31,9 +25,9 @@
     self = [super init];
     if (self)
     {
-        type_ = type;
-        tableName_ = [tableName copy];
-        itemId_ = [itemId copy];
+        _type = type;
+        _tableName = [tableName copy];
+        _itemId = [itemId copy];
     }
     
     return self;
@@ -48,12 +42,12 @@
         
         NSDictionary *rawItem = [serializer itemFromData:data withOriginalItem:nil ensureDictionary:YES orError:nil];
         
-        type_ = [[rawItem objectForKey:@"type"] integerValue];
-        itemId_ = [item objectForKey:@"itemId"];
-        tableName_ = [item objectForKey:@"table"];
-        operationId_ = [[item objectForKey:@"id"] integerValue];
+        _type = [[rawItem objectForKey:@"type"] integerValue];
+        _itemId = [item objectForKey:@"itemId"];
+        _tableName = [item objectForKey:@"table"];
+        _operationId = [[item objectForKey:@"id"] integerValue];
         
-        item_ = [rawItem objectForKey:@"item"];
+        _item = [rawItem objectForKey:@"item"];
     }
     return self;
 }

--- a/sdk/src/MSTableOperationError.m
+++ b/sdk/src/MSTableOperationError.m
@@ -55,7 +55,7 @@
     
     _code = error.code;
     _domain = [error.domain copy];
-    _description = [error.localizedDescription copy];
+    self.description = [error.localizedDescription copy];
     
     NSHTTPURLResponse *response = [error.userInfo objectForKey:MSErrorResponseKey];
     if (response) {

--- a/sdk/src/MSTableRequest.m
+++ b/sdk/src/MSTableRequest.m
@@ -76,9 +76,6 @@ static NSString *const httpDelete = @"DELETE";
 
 @implementation MSTableRequest
 
-@synthesize requestType = requestType_;
-@synthesize table = table_;
-
 
 #pragma mark * Private Initializer Method
 
@@ -88,7 +85,7 @@ static NSString *const httpDelete = @"DELETE";
 {
     self = [super initWithURL:url];
     if (self) {
-        table_ = table;
+        _table = table;
     }
     
     return self;
@@ -519,9 +516,6 @@ static NSString *const httpDelete = @"DELETE";
 
 @implementation MSTableItemRequest
 
-@synthesize itemId = itemId_;
-@synthesize item = item_;
-
 @end
 
 
@@ -530,9 +524,6 @@ static NSString *const httpDelete = @"DELETE";
 
 @implementation MSTableDeleteRequest
 
-@synthesize itemId = itemId_;
-@synthesize item = item_;
-
 @end
 
 
@@ -540,7 +531,5 @@ static NSString *const httpDelete = @"DELETE";
 
 
 @implementation MSTableReadQueryRequest
-
-@synthesize queryString = queryString_;
 
 @end

--- a/sdk/src/MSUser.m
+++ b/sdk/src/MSUser.m
@@ -10,9 +10,6 @@
 
 @implementation MSUser
 
-@synthesize userId = userId_;
-@synthesize mobileServiceAuthenticationToken = mobileServiceAuthenticationToken_;
-
 
 #pragma mark * Public Initializer Methods
 
@@ -22,7 +19,7 @@
     self = [super init];
     if(self)
     {
-        userId_ = userId;
+        _userId = userId;
     }
     return self;
 }

--- a/sdk/test/MSOfflinePassthroughHelper.m
+++ b/sdk/test/MSOfflinePassthroughHelper.m
@@ -10,13 +10,12 @@
 
 @implementation MSOfflinePassthroughHelper
 
-@synthesize data = data_;
 - (NSMutableDictionary *)data {
-    if (data_ == nil) {
-        data_ = [NSMutableDictionary new];
+    if (_data == nil) {
+        _data = [NSMutableDictionary new];
     }
     
-    return data_;
+    return _data;
 }
 
 - (BOOL) upsertItems:(NSArray *)items table:(NSString *)table orError:(NSError **)error

--- a/sdk/test/MSTestFilter.m
+++ b/sdk/test/MSTestFilter.m
@@ -6,13 +6,6 @@
 
 @implementation MSTestFilter
 
-@synthesize requestToUse = requestToUse_;
-@synthesize onInspectRequest = onInspectRequest_;
-@synthesize responseToUse = responseToUse_;
-@synthesize dataToUse = dataToUse_;
-@synthesize errorToUse = errorToUse_;
-@synthesize ignoreNextFilter = ignoreNextFilter_;
-
 +(MSTestFilter *)testFilterWithStatusCode:(NSInteger)statusCode
 {
     MSTestFilter *filter = [[MSTestFilter alloc] initWithStatusCode:statusCode data:nil];


### PR DESCRIPTION
Resolves #26 by using Xcode's auto property synthesis and appropriate underscore naming of ivars when using this feature.

Few cases where explicit `@synthesize` is required:
* readonly properties with getter
* overriding superclasses property

n.b. Unit tests are failing, but noted that the same unit tests fail with current master branch as this PR