### PR TITLE
SDK 3.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Azure Mobile Apps iOS SDK Change Log
 
-### Version 4.0.0
-- Support server login flow using SafariViewController. Google recently [announced](https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html) the deprecation of webview OAuth login. Going forward, all server login flow should use SafariViewController instead of webview.
-- Official support of Swift 3.0
+### Version 3.3.0
+- Support server login flow using SafariViewController. Google recently [announced](https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html) the deprecation of webview OAuth login. Going forward, all server login flow should use loginWithProvider:urlScheme:controller:animated:completion that uses SafariViewController instead of loginWithProvider:controller:animated:completion that uses webview.
+- Added support for Swift 3.0
 
 ### Version 3.2.0
 - Support Refresh Token

--- a/MicrosoftAzureMobile.podspec
+++ b/MicrosoftAzureMobile.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MicrosoftAzureMobile"
-  s.version      = "4.0.0"
+  s.version      = "3.3.0"
   s.summary      = "Client SDK for working with Azure Mobile Apps."
   s.homepage     = "http://azure.github.io/azure-mobile-apps-ios-client"
   s.license      = "Apache License, Version 2.0"
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.frameworks = "WebKit"
   s.source       = {
     :git => "https://github.com/Azure/azure-mobile-apps-ios-client.git",
-    :tag => "4.0.0"
+    :tag => "3.3.0"
   }
   s.source_files  = "sdk/src"
   s.exclude_files = "Classes/Exclude"

--- a/sdk/src/MicrosoftAzureMobile.h
+++ b/sdk/src/MicrosoftAzureMobile.h
@@ -28,8 +28,8 @@
 #import "MSTableOperationError.h"
 #import "MSUser.h"
 
-#define MicrosoftAzureMobileSdkMajorVersion 4
-#define MicrosoftAzureMobileSdkMinorVersion 0
+#define MicrosoftAzureMobileSdkMajorVersion 3
+#define MicrosoftAzureMobileSdkMinorVersion 3
 #define MicrosoftAzureMobileSdkBuildVersion 0
 
 #endif


### PR DESCRIPTION
#125 which tags the next SDK release as 4.0.0 is premature as there's no breaking changes. 3.3.0 release would make more sense.