### PR TITLE
Exclude MSLoginSafariViewController from Mac target as it depends on iOS specific SFSafariViewController

### DIFF
--- a/sdk/src/MSClient.h
+++ b/sdk/src/MSClient.h
@@ -15,7 +15,9 @@
 @class MSPush;
 @class MSSyncContext;
 @class MSLoginController;
+#if TARGET_OS_IPHONE
 @class MSLoginSafariViewController;
+#endif
 
 @protocol MSFilter;
 
@@ -72,8 +74,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// recommended for non-testing use.
 @property (nonatomic, strong, nullable) MSUser *currentUser;
 
+#if TARGET_OS_IPHONE
 /// An instance of |MSLoginSafariViewController|
 @property (nonatomic, strong, nonnull) MSLoginSafariViewController *loginSafariViewController;
+#endif
 
 /// @}
 

--- a/sdk/src/MSClient.m
+++ b/sdk/src/MSClient.m
@@ -15,7 +15,9 @@
 #import "MSSyncTable.h"
 #import "MSPush.h"
 #import "MSConnectionDelegate.h"
+#if TARGET_OS_IPHONE
 #import "MSLoginSafariViewController.h"
+#endif
 
 #pragma mark * MSClient Private Interface
 
@@ -100,9 +102,11 @@
         _login = [[MSLogin alloc] initWithClient:self];
         _push = [[MSPush alloc] initWithClient:self];
         _connectionDelegate = [[MSConnectionDelegate alloc] initWithClient:self];
-        
+
+#if TARGET_OS_IPHONE
         _loginSafariViewController = [[MSLoginSafariViewController alloc] initWithClient:self];
-        
+#endif
+		
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         _urlSession = [NSURLSession sessionWithConfiguration:configuration
                                                     delegate:self.connectionDelegate


### PR DESCRIPTION
Most of the MSLoginSafariViewController references had already been scoped to iOS only, we should fix the remaining to make the project compiled on Mac platform again, even though that implies lack of login support on Mac platform.