### PR TITLE
Fixed issues with test “AAD login via token”

### DIFF
--- a/e2etest/ZumoE2ETestApp.xcodeproj/project.pbxproj
+++ b/e2etest/ZumoE2ETestApp.xcodeproj/project.pbxproj
@@ -325,6 +325,9 @@
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 1;
+							};
 							com.apple.Push = {
 								enabled = 1;
 							};

--- a/e2etest/ZumoE2ETestApp/ZumoE2ETestApp.entitlements
+++ b/e2etest/ZumoE2ETestApp/ZumoE2ETestApp.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
**Repro steps:**
1. Run ZumoE2ETestApp
2. Go to "WebView login"
3. Click "Run tests"
4. Waiting for "Simplified login for AAD" test
5. Successfully login

**Result:**
- "Login via token for ADD" is failed. 
- "Sleep for 1 seconds" is freeze.

**Fixed** by adding Keychain Sharing capabilities -  [docs](https://github.com/AzureAD/microsoft-authentication-library-for-objc/wiki/Keychain-on-iOS#default-keychain-access-group)


![screen shot 2018-10-02 at 10 55 44](https://user-images.githubusercontent.com/40772628/46347390-03511c80-c654-11e8-8184-594d8ede990e.png)
