### PR TITLE
Fixed ios client.

### DIFF
--- a/e2etest/ZumoE2ETestApp/ZumoPushTests.m
+++ b/e2etest/ZumoE2ETestApp/ZumoPushTests.m
@@ -493,7 +493,7 @@ static NSString *topicSports = @"topic:Sports";
                               return;
                             }
 
-                            NSString *expectedTemplate = @"{\"templateName\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"boo!\\\"},\\\"extraprop\\\":\\\"($message)\\\"}\"}}";
+                            NSString *expectedTemplate = @"{\"templateName\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"boo!\\\"},\\\"extraprop\\\":\\\"($message)\\\"}\",\"tags\":[\"one\",\"templateName\",\"two\"]}}";
                             [client invokeAPI:@"verifyRegisterInstallationResult"
                                          body:nil
                                    HTTPMethod:@"GET"
@@ -524,7 +524,7 @@ static NSString *topicSports = @"topic:Sports";
     };
 
     MSCompletionBlock verifyPushTwo = ^(NSError *error) {
-      NSString *expectedTemplate = @"{\"t7\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"lookout!\\\"}}\"}}";
+      NSString *expectedTemplate = @"{\"t7\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"lookout!\\\"}}\", \"tags\":[\"t7\"]}}";
       [client invokeAPI:@"verifyRegisterInstallationResult"
                    body:nil
              HTTPMethod:@"GET"


### PR DESCRIPTION
**Problem:**
Old verification does not work due to additional tags parameters in notification hub response, e.g.:
```
Expected {"templateName":{"body":"{\"aps\":{\"alert\":\"boo!\"},\"extraprop\":\"($message)\"}"}}`
Found    {"templateName":{"body":"{\"aps\":{\"alert\":\"boo!\"},\"extraprop\":\"($message)\"}","tags":["one","templateName","two"]}}
```
**Changes:**
- Changed expected data.

---

Related PR: https://github.com/Azure/azure-mobile-apps-net-server/pull/252