### PR TITLE
Fix MSAPIConnection leak

### DIFF
--- a/e2etest/ZumoE2ETestApp/ZumoPushTests.m
+++ b/e2etest/ZumoE2ETestApp/ZumoPushTests.m
@@ -493,7 +493,7 @@ static NSString *topicSports = @"topic:Sports";
                               return;
                             }
 
-                            NSString *expectedTemplate = @"{\"templateName\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"boo!\\\"},\\\"extraprop\\\":\\\"($message)\\\"}\"}}";
+                            NSString *expectedTemplate = @"{\"templateName\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"boo!\\\"},\\\"extraprop\\\":\\\"($message)\\\"}\",\"tags\":[\"one\",\"templateName\",\"two\"]}}";
                             [client invokeAPI:@"verifyRegisterInstallationResult"
                                          body:nil
                                    HTTPMethod:@"GET"
@@ -524,7 +524,7 @@ static NSString *topicSports = @"topic:Sports";
     };
 
     MSCompletionBlock verifyPushTwo = ^(NSError *error) {
-      NSString *expectedTemplate = @"{\"t7\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"lookout!\\\"}}\"}}";
+      NSString *expectedTemplate = @"{\"t7\":{\"body\":\"{\\\"aps\\\":{\\\"alert\\\":\\\"lookout!\\\"}}\", \"tags\":[\"t7\"]}}";
       [client invokeAPI:@"verifyRegisterInstallationResult"
                    body:nil
              HTTPMethod:@"GET"

--- a/sdk/src/MSAPIConnection.m
+++ b/sdk/src/MSAPIConnection.m
@@ -54,6 +54,7 @@
             }
             
             completion(data, response, error);
+            connection = nil;
         };
     }
     


### PR DESCRIPTION
Fixed retain cycle: MSAPIConnection retains responseCompletion, responseCompletion block retains connection (MSAPIConnection). Set nil to connection block variable to break the cycle in the end of responseCompletion block.